### PR TITLE
Search icons

### DIFF
--- a/Breeze/actions/LO_lc_icons_breeze/lc_arrowshapes.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_arrowshapes.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_arrowshapes_up_down_arrow.svg">
+  <defs
+     id="defs3762" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="24.451298"
+     inkscape:cx="8.9889049"
+     inkscape:cy="16.217289"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1167"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="21.000014,2.9999782"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="6,0"
+       id="guide4155" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4167" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <path
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 566.28571,622.64789 4,-4 -4,-4 0,2 -3,0 -2,0 -3,0 0,-2 -4,4 4,4 0,-2 3,0 2,0 3,0 0,2 z"
+       id="rect3861-8"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_autoformat.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_autoformat.svg
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_autoformat.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="23.069359"
+     inkscape:cx="14.941807"
+     inkscape:cy="-4.0137385"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1252"
+     inkscape:window-height="1053"
+     inkscape:window-x="51"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4066" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4068" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4070" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4072" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4074" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4076" />
+    <sodipodi:guide
+       position="20,14.999983"
+       orientation="-16,0"
+       id="guide4078" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4080" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="9,20"
+       orientation="0,-5"
+       id="guide4124" />
+    <sodipodi:guide
+       position="12,4"
+       orientation="0,4"
+       id="guide4241" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       id="layer1-2"
+       inkscape:label="Capa 1"
+       transform="translate(0,-2e-5)">
+      <g
+         inkscape:label="Capa 1"
+         id="layer1-9"
+         transform="translate(-453.14286,376.00004)">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+           d="M 4.5,3 3.96875,3.96875 3,4.5 3.96875,5.03125 4.5,6 5.03125,5.03125 6,4.5 5.03125,3.96875 4.5,3 z M 9.5,3 8.96875,3.96875 8,4.5 8.96875,5.03125 9.5,6 10.03125,5.03125 11,4.5 10.03125,3.96875 9.5,3 z M 16.171875,3 3,16.171875 5.828125,19 19,5.828125 16.171875,3 z m -0.06836,1.4824219 1.414062,1.4140625 -3.097656,3.0996094 -1.416016,-1.4160157 3.09961,-3.0976562 z M 6.5,7 5.96875,7.96875 5,8.5 5.96875,9.03125 6.5,10 7.03125,9.03125 8,8.5 7.03125,7.96875 6.5,7 z"
+           transform="translate(453.14286,654.36218)"
+           id="rect4157" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_autosum.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_autosum.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_autosum.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.576748"
+     inkscape:cx="17.977692"
+     inkscape:cy="13.689426"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="1869"
+     inkscape:window-height="1060"
+     inkscape:window-x="49"
+     inkscape:window-y="-3"
+     inkscape:window-maximized="1"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4128" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <path
+       style="opacity:0.98692812;color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 4 4 L 4.46875 5 L 8.40625 12 L 4.46875 19 L 4 20 L 4.5 20 L 5 20 L 5.0625 20 L 5.5 20 L 20 20 L 20 17 L 20 16 L 18 16 L 18 17 L 18 18 L 7.1875 18 L 10.4375 12.25 L 10.59375 12 L 10.4375 11.75 L 7.1875 6 L 18 6 L 18 7 L 18 8 L 20 8 L 20 7 L 20 4 L 5.5 4 L 5.0625 4 L 5 4 L 4.5 4 L 4 4 z "
+       transform="translate(-1,1029.3622)"
+       id="rect3025" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_basicshapes.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_basicshapes.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_basicshapes_cube.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       id="perspective4090"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="25.15656"
+     inkscape:cx="8.7341323"
+     inkscape:cy="11.917398"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="1195"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4128" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       transform="translate(-461.71429,504.57145)"
+       id="layer1-6"
+       inkscape:label="Capa 1">
+      <path
+         transform="translate(460.71429,524.79077)"
+         d="M 20.000001,11.999979 11.999996,19.999984 3.9999914,11.999979 11.999996,3.9999743 z"
+         inkscape:randomized="0"
+         inkscape:rounded="0"
+         inkscape:flatsided="true"
+         sodipodi:arg2="0.78539816"
+         sodipodi:arg1="0"
+         sodipodi:r2="5.6568575"
+         sodipodi:r1="8.0000048"
+         sodipodi:cy="11.999979"
+         sodipodi:cx="11.999996"
+         sodipodi:sides="4"
+         id="path4026"
+         style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="star" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_calloutshapes.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_calloutshapes.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_calloutshapes_rectangular_callout.svg">
+  <defs
+     id="defs3762" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="24.451298"
+     inkscape:cx="7.6752966"
+     inkscape:cy="7.9613108"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1167"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="35.000019,2.999983"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="6,0"
+       id="guide4155" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <path
+       style="fill:#4d4d4d;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 6 4 C 4.8920104 4 4 4.8920001 4 6 L 4 14 C 4 15.108 4.8920104 16 6 16 L 8 16 L 8 20 L 12 16 L 18 16 C 19.10799 16 20 15.108 20 14 L 20 6 C 20 4.8920001 19.10799 4 18 4 L 6 4 z "
+       transform="translate(550.28571,606.64789)"
+       id="path4584" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_cancel.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_cancel.svg
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_downsearch.svg">
+  <defs
+     id="defs3762">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#ed868d;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         style="stop-color:#fbe6e8;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4435"
+       inkscape:collect="always">
+      <stop
+         id="stop4437"
+         offset="0"
+         style="stop-color:#c61423;stop-opacity:1" />
+      <stop
+         id="stop4439"
+         offset="1"
+         style="stop-color:#dc2b41;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4400"
+       id="linearGradient4394"
+       x1="19.999998"
+       y1="19.999998"
+       x2="43.999996"
+       y2="44"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7)" />
+    <linearGradient
+       id="linearGradient4400"
+       inkscape:collect="always">
+      <stop
+         id="stop4402"
+         offset="0"
+         style="stop-color:#020303;stop-opacity:1" />
+      <stop
+         id="stop4404"
+         offset="1"
+         style="stop-color:#424649;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4179"
+       x1="768.85718"
+       y1="201.93361"
+       x2="768.85718"
+       y2="177.93361"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7)" />
+    <linearGradient
+       gradientTransform="matrix(-1.4054053,0,0,1.4054053,804.69502,154.09579)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4435"
+       id="linearGradient4416"
+       x1="26.21154"
+       y1="43.999989"
+       x2="26.21154"
+       y2="6.9999886"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344-0">
+      <stop
+         style="stop-color:#ed868d;stop-opacity:1"
+         offset="0"
+         id="stop4346-8" />
+      <stop
+         style="stop-color:#fbe6e8;stop-opacity:1"
+         offset="1"
+         id="stop4348-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4435-3"
+       inkscape:collect="always">
+      <stop
+         id="stop4437-3"
+         offset="0"
+         style="stop-color:#c61423;stop-opacity:1" />
+      <stop
+         id="stop4439-7"
+         offset="1"
+         style="stop-color:#dc2b41;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4400-7"
+       id="linearGradient4394-8"
+       x1="19.999998"
+       y1="19.999998"
+       x2="43.999996"
+       y2="44"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7)" />
+    <linearGradient
+       id="linearGradient4400-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4402-9"
+         offset="0"
+         style="stop-color:#020303;stop-opacity:1" />
+      <stop
+         id="stop4404-4"
+         offset="1"
+         style="stop-color:#424649;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344-0"
+       id="linearGradient4179-4"
+       x1="768.85718"
+       y1="201.93361"
+       x2="768.85718"
+       y2="177.93361"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7)" />
+    <linearGradient
+       gradientTransform="matrix(-1.4054053,0,0,1.4054053,804.69502,154.09579)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4435-3"
+       id="linearGradient4416-2"
+       x1="26.21154"
+       y1="43.999989"
+       x2="26.21154"
+       y2="6.9999886"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="24.451298"
+     inkscape:cx="7.3919247"
+     inkscape:cy="5.4158779"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1167"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="35.000019,2.999983"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="6,0"
+       id="guide4155" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <g
+       transform="translate(552.2855,-422.71408)"
+       id="layer1-03"
+       inkscape:label="Capa 1">
+      <rect
+         transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,0,0)"
+         y="728.07611"
+         x="733.31848"
+         height="0.9999823"
+         width="21.628"
+         id="rect4103"
+         style="fill:#da4453;fill-opacity:1;stroke:none" />
+      <rect
+         style="fill:#da4453;fill-opacity:1;stroke:none"
+         id="rect4105"
+         width="21.628"
+         height="0.9999823"
+         x="-739.39008"
+         y="-744.63245"
+         transform="matrix(0.70710678,-0.70710678,-0.70710678,-0.70710678,0,0)" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_colorsettings.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_colorsettings.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_graphicfiltertoolbox.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="8.3304157"
+     inkscape:cy="15.694835"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="930"
+     inkscape:window-height="1053"
+     inkscape:window-x="51"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4128" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       transform="translate(-379.85714,490.28573)"
+       id="layer1-0"
+       inkscape:label="Capa 1">
+      <path
+         id="rect4108"
+         transform="translate(378.85714,540.07647)"
+         d="M 11,3 C 10.027093,6.4050342 7.6455537,9.3322765 6.5957031,11.675781 6.2282987,12.372552 6,13.15458 6,14 c 0,2.770002 2.2299982,5 5,5 2.770002,0 5,-2.229998 5,-5 0,-0.84542 -0.228299,-1.627448 -0.595703,-2.324219 C 14.354447,9.3322765 11.972897,6.4050342 11,3 z m 2.283203,7.716797 C 14.3209,11.438005 15,12.635082 15,14 15,16.216002 13.216002,18 11,18 9.6350429,18 8.4379979,17.320951 7.7167969,16.283203 8.363845,16.732907 9.148916,17 10,17 c 2.216002,0 4,-1.783998 4,-4 0,-0.851084 -0.267093,-1.636155 -0.716797,-2.283203 z"
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="opacity:0.98692812;color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 18.998895,1040.2684 a 1,1 0 0 0 -1,-0.9062 1,1 0 0 0 -1,1 1,1 0 0 0 1,1 1,1 0 0 0 1,-1 1,1 0 0 0 0,-0.094 z m 0,4 a 1,1 0 0 0 -1,-0.9062 1,1 0 0 0 -1,1 1,1 0 0 0 1,1 1,1 0 0 0 1,-1 1,1 0 0 0 0,-0.094 z m 0,4 a 1,1 0 0 0 -1,-0.9062 1,1 0 0 0 -1,1 1,1 0 0 0 1,1 1,1 0 0 0 1,-1 1,1 0 0 0 0,-0.094 z"
+       id="rect3016"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_downsearch.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_downsearch.svg
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_calloutshapes_cloud_callout.svg">
+  <defs
+     id="defs3762">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#ed868d;stop-opacity:1"
+         offset="0"
+         id="stop4346" />
+      <stop
+         style="stop-color:#fbe6e8;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4435"
+       inkscape:collect="always">
+      <stop
+         id="stop4437"
+         offset="0"
+         style="stop-color:#c61423;stop-opacity:1" />
+      <stop
+         id="stop4439"
+         offset="1"
+         style="stop-color:#dc2b41;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4400"
+       id="linearGradient4394"
+       x1="19.999998"
+       y1="19.999998"
+       x2="43.999996"
+       y2="44"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7)" />
+    <linearGradient
+       id="linearGradient4400"
+       inkscape:collect="always">
+      <stop
+         id="stop4402"
+         offset="0"
+         style="stop-color:#020303;stop-opacity:1" />
+      <stop
+         id="stop4404"
+         offset="1"
+         style="stop-color:#424649;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4179"
+       x1="768.85718"
+       y1="201.93361"
+       x2="768.85718"
+       y2="177.93361"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7)" />
+    <linearGradient
+       gradientTransform="matrix(-1.4054053,0,0,1.4054053,804.69502,154.09579)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4435"
+       id="linearGradient4416"
+       x1="26.21154"
+       y1="43.999989"
+       x2="26.21154"
+       y2="6.9999886"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344-0">
+      <stop
+         style="stop-color:#ed868d;stop-opacity:1"
+         offset="0"
+         id="stop4346-8" />
+      <stop
+         style="stop-color:#fbe6e8;stop-opacity:1"
+         offset="1"
+         id="stop4348-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4435-3"
+       inkscape:collect="always">
+      <stop
+         id="stop4437-3"
+         offset="0"
+         style="stop-color:#c61423;stop-opacity:1" />
+      <stop
+         id="stop4439-7"
+         offset="1"
+         style="stop-color:#dc2b41;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4400-7"
+       id="linearGradient4394-8"
+       x1="19.999998"
+       y1="19.999998"
+       x2="43.999996"
+       y2="44"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7)" />
+    <linearGradient
+       id="linearGradient4400-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4402-9"
+         offset="0"
+         style="stop-color:#020303;stop-opacity:1" />
+      <stop
+         id="stop4404-4"
+         offset="1"
+         style="stop-color:#424649;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344-0"
+       id="linearGradient4179-4"
+       x1="768.85718"
+       y1="201.93361"
+       x2="768.85718"
+       y2="177.93361"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7)" />
+    <linearGradient
+       gradientTransform="matrix(-1.4054053,0,0,1.4054053,804.69502,154.09579)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4435-3"
+       id="linearGradient4416-2"
+       x1="26.21154"
+       y1="43.999989"
+       x2="26.21154"
+       y2="6.9999886"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="24.451298"
+     inkscape:cx="7.3919247"
+     inkscape:cy="5.4158779"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1167"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="35.000019,2.999983"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="6,0"
+       id="guide4155" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <g
+       transform="translate(551.28571,-423.06783)"
+       id="layer1-0"
+       inkscape:label="Capa 1">
+      <path
+         id="rect4176"
+         transform="translate(-5e-7,1030.3622)"
+         d="M 3.7070312,7 3,7.7070312 l 6.125,6.1249998 1.875,1.875 1.875,-1.875 L 19,7.7070312 18.292969,7 12.167969,13.125 11,14.292969 9.8320312,13.125 3.7070312,7 z"
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_drawcaption.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_drawcaption.svg
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_drawselect.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="6.9999886"
+       x2="26.21154"
+       y1="43.999989"
+       x1="26.21154"
+       id="linearGradient4416"
+       xlink:href="#linearGradient4435"
+       inkscape:collect="always"
+       gradientTransform="matrix(-1.4054053,0,0,1.4054053,804.69502,154.09579)" />
+    <linearGradient
+       gradientTransform="translate(0,-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="177.93361"
+       x2="768.85718"
+       y1="201.93361"
+       x1="768.85718"
+       id="linearGradient4179"
+       xlink:href="#linearGradient4344"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4400">
+      <stop
+         style="stop-color:#020303;stop-opacity:1"
+         offset="0"
+         id="stop4402" />
+      <stop
+         style="stop-color:#424649;stop-opacity:0"
+         offset="1"
+         id="stop4404" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="44"
+       x2="43.999996"
+       y1="19.999998"
+       x1="19.999998"
+       id="linearGradient4394"
+       xlink:href="#linearGradient4400"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4435">
+      <stop
+         style="stop-color:#c61423;stop-opacity:1"
+         offset="0"
+         id="stop4437" />
+      <stop
+         style="stop-color:#dc2b41;stop-opacity:1"
+         offset="1"
+         id="stop4439" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4344"
+       inkscape:collect="always">
+      <stop
+         id="stop4346"
+         offset="0"
+         style="stop-color:#ed868d;stop-opacity:1" />
+      <stop
+         id="stop4348"
+         offset="1"
+         style="stop-color:#fbe6e8;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="33.683996"
+     inkscape:cx="13.024376"
+     inkscape:cy="11.261889"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1473"
+     inkscape:window-height="1042"
+     inkscape:window-x="161"
+     inkscape:window-y="41"
+     inkscape:window-maximized="0"
+     units="px"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4085" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4087" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4089" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4091" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4093" />
+    <sodipodi:guide
+       position="2,4"
+       orientation="0,16"
+       id="guide4095" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4097" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4099" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4123" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,2.000001"
+       id="guide4125" />
+    <sodipodi:guide
+       position="5,20"
+       orientation="-16,0"
+       id="guide4127" />
+    <sodipodi:guide
+       position="6.000001,20"
+       orientation="0,-2.000001"
+       id="guide4129" />
+    <sodipodi:guide
+       position="19,20"
+       orientation="16,0"
+       id="guide4131" />
+    <sodipodi:guide
+       position="18,4"
+       orientation="0,2"
+       id="guide4133" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4135" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-2"
+       id="guide4137" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       d="M 9 4 L 9 9 L 7.28125 9 L 6.125 9 L 6 9 L 5.1875 9 L 5.03125 9.8125 L 3.03125 19.8125 L 3 20 L 5 20 L 6.8125 11 L 9 11 L 9 16 L 10.25 16 L 11.5 16 L 14 16 L 15.25 16 L 19 16 L 19 4 L 9 4 z M 10 5 L 18 5 L 18 15 L 10 15 L 10 5 z "
+       transform="translate(-1,1029.3622)"
+       id="path4561" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_drawtext.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_drawtext.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48+devel r"
+   sodipodi:docname="draw-text.svg">
+  <defs
+     id="defs3762" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="23.519932"
+     inkscape:cx="8.3895802"
+     inkscape:cy="13.496396"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1366"
+     inkscape:window-height="668"
+     inkscape:window-x="-2"
+     inkscape:window-y="23"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="false">
+    <sodipodi:guide
+       position="-1.4433594e-05,24.000012"
+       orientation="24,0"
+       id="guide4115" />
+    <sodipodi:guide
+       position="-1.4433594e-05,1.1816406e-05"
+       orientation="0,24"
+       id="guide4117" />
+    <sodipodi:guide
+       position="23.999986,1.1816406e-05"
+       orientation="-24,0"
+       id="guide4119" />
+    <sodipodi:guide
+       position="23.999986,24.000012"
+       orientation="0,-24"
+       id="guide4121" />
+    <sodipodi:guide
+       position="2.9999856,21.000012"
+       orientation="18,0"
+       id="guide4123" />
+    <sodipodi:guide
+       position="2.9999856,3.0000118"
+       orientation="0,18"
+       id="guide4125" />
+    <sodipodi:guide
+       position="20.999986,3.0000118"
+       orientation="-18,0"
+       id="guide4127" />
+    <sodipodi:guide
+       position="20.999986,21.000012"
+       orientation="0,-18"
+       id="guide4129" />
+    <sodipodi:guide
+       position="3.9999856,20.000012"
+       orientation="16,0"
+       id="guide4131" />
+    <sodipodi:guide
+       position="3.9999856,4.0000118"
+       orientation="0,16"
+       id="guide4133" />
+    <sodipodi:guide
+       position="19.999986,4.0000118"
+       orientation="-16,0"
+       id="guide4135" />
+    <sodipodi:guide
+       position="19.999986,20.000012"
+       orientation="0,-16"
+       id="guide4137" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4139" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28572,-606.6479)">
+    <path
+       style="opacity:1;fill:#4d4d4d;fill-opacity:1;stroke:none"
+       d="M 5 4 L 5 18 L 4 18 L 4 19 L 5 19 L 5 20 L 6 20 L 6 19 L 18 19 L 18 20 L 19 20 L 19 19 L 20 19 L 20 18 L 19 18 L 19 4 L 18 4 L 18 18 L 6 18 L 6 4 L 5 4 z M 7 5 L 7 7 L 11 7 L 11 17 L 13 17 L 13 7 L 17 7 L 17 5 L 7 5 z "
+       transform="translate(550.28572,606.6479)"
+       id="rect4112" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_ellipse.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_ellipse.svg
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_rect.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="23.818182"
+     inkscape:cx="9.751946"
+     inkscape:cy="9.3437126"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1473"
+     inkscape:window-height="1042"
+     inkscape:window-x="1793"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     units="px"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4085" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4087" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4089" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4091" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4093" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4095" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4097" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4099" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4123" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,2.000001"
+       id="guide4125" />
+    <sodipodi:guide
+       position="5,20"
+       orientation="-16,0"
+       id="guide4127" />
+    <sodipodi:guide
+       position="6.000001,20"
+       orientation="0,-2.000001"
+       id="guide4129" />
+    <sodipodi:guide
+       position="19,20"
+       orientation="16,0"
+       id="guide4131" />
+    <sodipodi:guide
+       position="18,4"
+       orientation="0,2"
+       id="guide4133" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4135" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-2"
+       id="guide4137" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <path
+       sodipodi:type="arc"
+       style="opacity:0.98692812;color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path4605"
+       sodipodi:cx="12"
+       sodipodi:cy="12.000017"
+       sodipodi:rx="8"
+       sodipodi:ry="6"
+       d="m 20,12.000017 a 8,6 0 1 1 -16,0 8,6 0 1 1 16,0 z"
+       transform="translate(-1,1029.3622)" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_extrusiontoggle.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_extrusiontoggle.svg
@@ -1,0 +1,3916 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_extrusiontoggle.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       id="perspective4090"
+       inkscape:persp3d-origin="14.566744 : 8 : 1"
+       inkscape:vp_z="2.5667437 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="26.566744 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4146"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-8" />
+    <linearGradient
+       y2="147.25354"
+       x2="-160.9847"
+       y1="115.75639"
+       x1="-160.9847"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10051"
+       xlink:href="#linearGradient6004"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6004-0">
+      <stop
+         id="stop6006-2"
+         offset="0"
+         style="stop-color:#5a646e;stop-opacity:1;" />
+      <stop
+         id="stop6008-8"
+         offset="1"
+         style="stop-color:#475057;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="147.25354"
+       x2="-160.9847"
+       y1="115.75639"
+       x1="-160.9847"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6416-0"
+       xlink:href="#linearGradient6004-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6346"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4948">
+      <stop
+         id="stop4950"
+         offset="0"
+         style="stop-color:#5a646e;stop-opacity:1;" />
+      <stop
+         id="stop4952"
+         offset="1"
+         style="stop-color:#475057;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="147.25354"
+       x2="-160.9847"
+       y1="115.75639"
+       x1="-160.9847"
+       gradientTransform="translate(0.01553073,0.49882594)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6108"
+       xlink:href="#linearGradient6004"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-22-8-9">
+      <stop
+         id="stop3858-16-1-9"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857-9-8"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-22-8-9"
+       id="linearGradient7385-8-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       x1="634.62195"
+       y1="524.59497"
+       x2="639.1156"
+       y2="524.59497" />
+    <linearGradient
+       id="linearGradient4913">
+      <stop
+         id="stop4915"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4917"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4911"
+       xlink:href="#linearGradient4560-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4905">
+      <stop
+         id="stop4907"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4909"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4898">
+      <stop
+         id="stop4900"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4902"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7891-4"
+       xlink:href="#linearGradient3856-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4891">
+      <stop
+         id="stop4893"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4895"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7887-6"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4884">
+      <stop
+         id="stop4886"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4888"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7885-5"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4877">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7889-8"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-4-2">
+      <stop
+         id="stop3858-5-3"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-7-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="translate(-153.98289,90.060334)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7883-8"
+       xlink:href="#linearGradient3856-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4866">
+      <stop
+         id="stop4868"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4870"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4864"
+       xlink:href="#linearGradient4560-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4560-9">
+      <stop
+         id="stop4562-2"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4564-4"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4850">
+      <stop
+         id="stop4852"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4854"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4848"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4842">
+      <stop
+         id="stop4844"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4846"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6295"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4783">
+      <stop
+         id="stop4785"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4787"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4781"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-2-1">
+      <stop
+         id="stop3858-6-5"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-4"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5991"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-22-3-1">
+      <stop
+         id="stop3858-16-8-9"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857-0-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5989"
+       xlink:href="#linearGradient3856-22-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6004">
+      <stop
+         id="stop6006"
+         offset="0"
+         style="stop-color:#5a646e;stop-opacity:1;" />
+      <stop
+         id="stop6008"
+         offset="1"
+         style="stop-color:#475057;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="147.25354"
+       x2="-160.9847"
+       y1="115.75639"
+       x1="-160.9847"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6093"
+       xlink:href="#linearGradient6004"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5117"
+       xlink:href="#linearGradient3856-22"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="matrix(1.0005238,0,0,0.91257347,-101.00421,8.4946302)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5093"
+       xlink:href="#linearGradient3856-6-78-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.58937"
+       x2="543.96741"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.73829795,0,0,0.91833374,-103.78254,170.81814)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5091"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7523"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7521"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-22-82"
+       id="linearGradient7385-81"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       x1="634.62195"
+       y1="524.59497"
+       x2="639.1156"
+       y2="524.59497" />
+    <linearGradient
+       id="linearGradient3856-22-82">
+      <stop
+         id="stop3858-16-89"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857-07"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8274-2"
+       xlink:href="#linearGradient3856-22-82"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-22-8">
+      <stop
+         id="stop3858-16-1"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8274-6"
+       xlink:href="#linearGradient3856-22-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-22-3">
+      <stop
+         id="stop3858-16-8"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857-0"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8274-4"
+       xlink:href="#linearGradient3856-22-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-6-78-8-96">
+      <stop
+         id="stop3858-71-3-29-5"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5-10"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-78-8-89">
+      <stop
+         id="stop3858-71-3-29-84"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5-1"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-3">
+      <stop
+         id="stop3858-51"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-201"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1029.3622"
+       x2="1061.5686"
+       y1="1029.3622"
+       x1="1014.0001"
+       id="linearGradient6710-8"
+       xlink:href="#linearGradient3856-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6672">
+      <stop
+         id="stop6674"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6676"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5710-0"
+       xlink:href="#linearGradient3856-60"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6665">
+      <stop
+         id="stop6667"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6669"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6658">
+      <stop
+         id="stop6660"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6662"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6651">
+      <stop
+         id="stop6653"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6655"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6644">
+      <stop
+         id="stop6646"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6648"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6637">
+      <stop
+         id="stop6639"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6641"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6630">
+      <stop
+         id="stop6632"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6634"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6623">
+      <stop
+         id="stop6625"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6627"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6616">
+      <stop
+         id="stop6618"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6620"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-60">
+      <stop
+         id="stop3858-165"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-75"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6558">
+      <stop
+         id="stop6560"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6562"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="659.23761"
+       x2="1262.1884"
+       y1="659.23761"
+       x1="1259.8062"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7805-0"
+       xlink:href="#linearGradient3856-11-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-11-5">
+      <stop
+         id="stop3858-61-4"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-97-2"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5997">
+      <stop
+         id="stop5999"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6001"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7887-4"
+       xlink:href="#linearGradient3856-13"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5990">
+      <stop
+         id="stop5992"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop5994"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-13">
+      <stop
+         id="stop3858-8"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-93"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5867-40-6"
+       id="linearGradient5681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3144.7365,-68.655864)"
+       x1="-327.40073"
+       y1="138.68115"
+       x2="-281.86459"
+       y2="138.68115" />
+    <linearGradient
+       id="linearGradient5673">
+      <stop
+         id="stop5675"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5677"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5867-40-6"
+       id="linearGradient5671"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(679.2638,226.89)"
+       x1="-327.40073"
+       y1="138.68115"
+       x2="-281.86459"
+       y2="138.68115" />
+    <linearGradient
+       id="linearGradient5867-40-6">
+      <stop
+         id="stop5869-9-8"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-48-5"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5867-40-6"
+       id="linearGradient8009-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(679.2638,226.89)"
+       x1="-327.40073"
+       y1="138.68115"
+       x2="-281.86459"
+       y2="138.68115" />
+    <linearGradient
+       id="linearGradient5522">
+      <stop
+         id="stop5524"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5526"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,176)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5520"
+       xlink:href="#linearGradient5867-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-1">
+      <stop
+         id="stop5869-52"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-7"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,176)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7951-71"
+       xlink:href="#linearGradient5867-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7025-7">
+      <stop
+         id="stop7027-7"
+         offset="0"
+         style="stop-color:#232629;stop-opacity:0.3137255;" />
+      <stop
+         id="stop7029-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7025-7"
+       id="linearGradient4385-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99886918,0,0,0.89231233,-282.01404,100.04625)"
+       x1="-51.551456"
+       y1="669.02393"
+       x2="-51.551456"
+       y2="671.74512" />
+    <linearGradient
+       id="linearGradient7025">
+      <stop
+         id="stop7027"
+         offset="0"
+         style="stop-color:#232629;stop-opacity:0.3137255;" />
+      <stop
+         id="stop7029"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="671.74512"
+       x2="-51.551456"
+       y1="669.02393"
+       x1="-51.551456"
+       gradientTransform="matrix(0.99886918,0,0,0.89231233,-282.01404,96.046246)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7134"
+       xlink:href="#linearGradient7025"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8077">
+      <stop
+         id="stop8079"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop8081"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-22">
+      <stop
+         id="stop3858-16"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5867-40"
+       id="linearGradient8009"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(679.2638,226.89)"
+       x1="-327.40073"
+       y1="138.68115"
+       x2="-281.86459"
+       y2="138.68115" />
+    <linearGradient
+       id="linearGradient8001">
+      <stop
+         id="stop8003"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop8005"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,176)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7999"
+       xlink:href="#linearGradient5867-40"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-40">
+      <stop
+         id="stop5869-9"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-48"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,176)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7951-7"
+       xlink:href="#linearGradient5867-40"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(0,176)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7951"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7893"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7889"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7881"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="920.40436"
+       x2="2397.3689"
+       y1="920.40436"
+       x1="2284.8362"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13430"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-6-78-8-8">
+      <stop
+         id="stop3858-71-3-29-4"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5-0"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="287.44943"
+       x2="-371.23654"
+       y1="287.44943"
+       x1="-387.84259"
+       id="linearGradient13238"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-6-78-8-9-0">
+      <stop
+         id="stop3858-71-3-29-8-8"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5-6-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="matrix(1.0005238,0,0,0.91257347,-102.10589,8.4074)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11658-6-2"
+       xlink:href="#linearGradient3856-6-78-8-9-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-6-78-8-9">
+      <stop
+         id="stop3858-71-3-29-8"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5-6"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13045"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13041"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13033"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="287.44943"
+       x2="-371.23654"
+       y1="287.44943"
+       x1="-387.84259"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13023"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13017"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13013"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13005"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13003"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientTransform="translate(154.01931,-4.1463699e-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12993"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12989"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12985"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12977"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11674"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11670"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11662"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="287.44943"
+       x2="-371.23654"
+       y1="287.44943"
+       x1="-387.84259"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11654"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11648"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11644"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11636"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11634"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientTransform="translate(154.01931,-4.1463699e-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11624"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11620"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11616"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11608"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientTransform="translate(154.01931,-0.90029535)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8926"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8922"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8918"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8910"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="287.44943"
+       x2="-371.23654"
+       y1="287.44943"
+       x1="-387.84259"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8440"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8433"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8429"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8421"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(0,-0.89973913)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8419"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientTransform="translate(246.01931,-4.1463699e-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7981"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5867-88"
+       id="linearGradient7932"
+       gradientUnits="userSpaceOnUse"
+       x1="-327.40073"
+       y1="138.68115"
+       x2="-281.86459"
+       y2="138.68115"
+       gradientTransform="translate(154.01931,-4.1463699e-4)" />
+    <linearGradient
+       id="linearGradient7924">
+      <stop
+         id="stop7926"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop7928"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       id="linearGradient7922"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-88">
+      <stop
+         id="stop5869-12"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-1"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       id="linearGradient6967-5"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7904"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7900"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7892"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       id="linearGradient7432"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7422"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7418"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7410"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       id="linearGradient6967"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="287.44943"
+       x2="-371.23654"
+       y1="287.44943"
+       x1="-387.84259"
+       id="linearGradient6959"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6949"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6945"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6937"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6497"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6493"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6485"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5264"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5260"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5252"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-82">
+      <stop
+         id="stop5869-2"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-6"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="translate(-105.07028,-2.0739375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5397-54"
+       xlink:href="#linearGradient5867-82"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-2">
+      <stop
+         id="stop5869-4"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-3"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="translate(-105.07028,-2.0739375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5397-5"
+       xlink:href="#linearGradient5867-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5403"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="920.40436"
+       x2="2397.3689"
+       y1="920.40436"
+       x1="2284.8362"
+       id="linearGradient7367"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4517">
+      <stop
+         id="stop4519"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4521"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4510">
+      <stop
+         id="stop4512"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4514"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4503">
+      <stop
+         id="stop4505"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4507"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-11">
+      <stop
+         id="stop3858-61"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-97"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4492">
+      <stop
+         id="stop4494"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4496"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-7-2">
+      <stop
+         id="stop3858-55-2"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-74-0"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13623"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13619"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13611"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13165"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13161"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13153"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="matrix(0.99999929,0,0,0.98614895,-280.5697,-0.05816442)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12709"
+       xlink:href="#linearGradient5867-5-29"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="translate(-247.36931,-2.5813017)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12707"
+       xlink:href="#linearGradient3856-6-73"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,-147.12225,26.027448)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12705"
+       xlink:href="#linearGradient3856-97-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="412.62933"
+       x2="108.65295"
+       y1="412.62933"
+       x1="-595.83929"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12703"
+       xlink:href="#linearGradient3856-10"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-6-78-32">
+      <stop
+         id="stop3858-71-3-9"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-7"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-6-78-32"
+       id="linearGradient10572-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-105.07028,-2.0739375)"
+       x1="61.56308"
+       y1="140.46777"
+       x2="237.56308"
+       y2="140.46777" />
+    <linearGradient
+       id="linearGradient3856-6-78-8">
+      <stop
+         id="stop3858-71-3-29"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-6-78-8"
+       id="linearGradient10572-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-105.07028,-2.0739375)"
+       x1="61.56308"
+       y1="140.46777"
+       x2="237.56308"
+       y2="140.46777" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12437"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12433"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12425"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11858"
+       xlink:href="#linearGradient3856-97"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-97-8">
+      <stop
+         id="stop3858-68-0"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-11-7"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5859-2-9"
+       xlink:href="#linearGradient3856-97-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10781">
+      <stop
+         id="stop10783"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10785"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10779"
+       xlink:href="#linearGradient3856-97"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10773">
+      <stop
+         id="stop10775"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10777"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10555-0"
+       xlink:href="#linearGradient3856-97"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10718">
+      <stop
+         id="stop10720"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10722"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10711">
+      <stop
+         id="stop10713"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10715"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-78-3">
+      <stop
+         id="stop3858-71-3-2"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-3"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10696">
+      <stop
+         id="stop10698"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10700"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10685">
+      <stop
+         id="stop10687"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10689"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10683"
+       xlink:href="#linearGradient3856-97"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10677">
+      <stop
+         id="stop10679"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10681"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5865-4"
+       xlink:href="#linearGradient3856-97"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10624">
+      <stop
+         id="stop10626"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10628"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10617">
+      <stop
+         id="stop10619"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10621"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10610">
+      <stop
+         id="stop10612"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10614"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-97">
+      <stop
+         id="stop3858-68"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-11"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-78">
+      <stop
+         id="stop3858-71-3"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="translate(-248.36932,-2.5813017)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10146-3"
+       xlink:href="#linearGradient3856-6-78"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10555"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-5-9">
+      <stop
+         id="stop5869-1-5"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-8-4"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-74">
+      <stop
+         id="stop3858-71-0"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-67">
+      <stop
+         id="stop3858-6"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-85"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867-5-29">
+      <stop
+         id="stop5869-1-00"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-8-2"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-73">
+      <stop
+         id="stop3858-71-7"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-4"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-45-3-2">
+      <stop
+         id="stop3858-4-8-7"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-81-5-0"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-10">
+      <stop
+         id="stop3858-05"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-1"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-45-3">
+      <stop
+         id="stop3858-4-8"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-81-5"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-45-3"
+       id="linearGradient9754-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,99.531372,25.216232)"
+       x1="-344.67334"
+       y1="145.9536"
+       x2="105.38848"
+       y2="145.9536" />
+    <linearGradient
+       id="linearGradient3856-45">
+      <stop
+         id="stop3858-4"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-81"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4406-0"
+       xlink:href="#linearGradient3856-45"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-5-2">
+      <stop
+         id="stop5869-1-0"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-8-3"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9536">
+      <stop
+         id="stop9538"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop9540"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-7">
+      <stop
+         id="stop3858-71-4"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-3"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-1">
+      <stop
+         id="stop3858-14"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-20"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9264">
+      <stop
+         id="stop9266"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop9268"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867-5">
+      <stop
+         id="stop5869-1"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-8"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6">
+      <stop
+         id="stop3858-71"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867-8-5">
+      <stop
+         id="stop5869-7-6"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-4-3"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.79079"
+       x2="236.92349"
+       y1="138.79079"
+       x1="-348.09015"
+       id="linearGradient5873-3-3"
+       xlink:href="#linearGradient5867-8-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8308">
+      <stop
+         id="stop8310"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop8312"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8306"
+       xlink:href="#linearGradient3856-27"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-27">
+      <stop
+         id="stop3858-2"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-90"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3492-8"
+       xlink:href="#linearGradient3856-27"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8250">
+      <stop
+         id="stop8252"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop8254"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867-8">
+      <stop
+         id="stop5869-7"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-4"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7647">
+      <stop
+         id="stop7649"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop7651"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7645"
+       xlink:href="#linearGradient3856-77"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-77">
+      <stop
+         id="stop3858-7"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-0"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3492-2"
+       xlink:href="#linearGradient3856-77"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7589">
+      <stop
+         id="stop7591"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop7593"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867-4">
+      <stop
+         id="stop5869-5"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-9"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7530"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7526"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7518"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7104"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7102"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6656"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6317"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-2-8">
+      <stop
+         id="stop3858-1-7"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-73-5"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-2-8"
+       id="linearGradient6215-4"
+       gradientUnits="userSpaceOnUse"
+       x1="-580.12299"
+       y1="1049.3584"
+       x2="-534.38489"
+       y2="1049.3584"
+       gradientTransform="translate(10.445229,-1.0229601)" />
+    <linearGradient
+       id="linearGradient3856-2">
+      <stop
+         id="stop3858-1"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-73"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1049.3584"
+       x2="-534.38489"
+       y1="1049.3584"
+       x1="-580.12299"
+       id="linearGradient6198-7"
+       xlink:href="#linearGradient3856-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6188"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6186"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5712"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5710"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5708"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5706"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5704"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5702"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5700"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5698"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5696"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5694"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       id="linearGradient5576"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective9" />
+    <linearGradient
+       id="linearGradient5424">
+      <stop
+         id="stop5426"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop5428"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-7">
+      <stop
+         id="stop3858-55"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-74"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5344">
+      <stop
+         id="stop5346"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop5348"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5216-2-9">
+      <stop
+         id="stop5218-6-4"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop5220-6-3"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5268">
+      <stop
+         id="stop5270"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop5272"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5216-2">
+      <stop
+         id="stop5218-6"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop5220-6"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-94">
+      <stop
+         id="stop3858-3"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-2"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9166"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1038.1689"
+       x2="2324.1321"
+       y1="1038.1689"
+       x1="2295.6143"
+       id="linearGradient9155"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3472">
+      <stop
+         id="stop3474"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop3476"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5216">
+      <stop
+         id="stop5218"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop5220"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4926"
+       id="linearGradient3455"
+       gradientUnits="userSpaceOnUse"
+       x1="1309.951"
+       y1="1089.2706"
+       x2="1402.2245"
+       y2="1089.2706"
+       gradientTransform="translate(-79.138944,-38.444717)" />
+    <linearGradient
+       id="linearGradient3426">
+      <stop
+         style="stop-color:#232629;stop-opacity:1;"
+         offset="0"
+         id="stop3428" />
+      <stop
+         style="stop-color:#232629;stop-opacity:1;"
+         offset="1"
+         id="stop3430" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1089.2706"
+       x2="1402.2245"
+       y1="1089.2706"
+       x1="1309.951"
+       id="linearGradient3424"
+       xlink:href="#linearGradient4926"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4926">
+      <stop
+         style="stop-color:#232629;stop-opacity:1;"
+         offset="0"
+         id="stop4928" />
+      <stop
+         style="stop-color:#232629;stop-opacity:1;"
+         offset="1"
+         id="stop4930" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1089.2706"
+       x2="1402.2245"
+       y1="1089.2706"
+       x1="1309.951"
+       id="linearGradient4995"
+       xlink:href="#linearGradient4926"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8877"
+       xlink:href="#linearGradient3856-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8875"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8873"
+       xlink:href="#linearGradient3856-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8871"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8869"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8867"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="translate(-153.98289,90.060334)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8865"
+       xlink:href="#linearGradient3856-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8863"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="355.87778"
+       x2="421.4332"
+       y1="355.87778"
+       x1="416.93951"
+       gradientTransform="translate(-0.30005314,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8861"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8859"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.58937"
+       x2="543.96741"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8857"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8447"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8443"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8435"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8019"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8015"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8007"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-9">
+      <stop
+         id="stop3858-0"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5863-5"
+       xlink:href="#linearGradient3856-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7543"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7341"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7137"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6883"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6879"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6871"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6459"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6447"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="412.62933"
+       x2="108.65295"
+       y1="412.62933"
+       x1="-595.83929"
+       id="linearGradient6023"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.98634"
+       x2="99.085938"
+       y1="138.98634"
+       x1="-595.75684"
+       id="linearGradient5931"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5865"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5863"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5861"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5859"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5857"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       id="linearGradient5568"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       id="linearGradient4939"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       id="linearGradient4767"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4560">
+      <stop
+         id="stop4562"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4564"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-4">
+      <stop
+         id="stop3858-5"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-7"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4515"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4472"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4470"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4468"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4466"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4464"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3492"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3609"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       id="linearGradient4486"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4408"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4366"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4364"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4362"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4288"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4273"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       id="linearGradient4259"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4237"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4235"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(0.98585011,0,0,0.77830794,-6.623518,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4195"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4193"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(0.98395085,0,0,0.77830794,-7.2813589,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4108"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4106"
+       xlink:href="#linearGradient4197"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="395.46878"
+       x2="209.60085"
+       y1="395.46878"
+       x1="197.93234"
+       id="linearGradient4058"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.0003619,0,0,0.14156624,0.01136409,97.590745)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4040"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1,0,0,0.78698562,0,23.25948)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4024"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4022"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="514.716"
+       x2="123.01467"
+       y1="110.92937"
+       x1="-308.13144"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3974"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="736.81"
+       x2="880.45819"
+       y1="408.8381"
+       x1="416.70969"
+       id="linearGradient3934"
+       xlink:href="#linearGradient3928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3766">
+      <stop
+         id="stop3768"
+         offset="0"
+         style="stop-color:#789fc5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b3c7db;stop-opacity:0.990991;"
+         offset="0.5"
+         id="stop3854" />
+      <stop
+         id="stop3770"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856">
+      <stop
+         id="stop3858"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="0"
+         id="stop3866" />
+      <stop
+         id="stop3874"
+         offset="0.51315862"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3870"
+         offset="0.64315861"
+         style="stop-color:#8bcff2;stop-opacity:1;" />
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="0.76999998"
+         id="stop3872" />
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="1"
+         id="stop3868" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3900">
+      <stop
+         style="stop-color:#2a78a0;stop-opacity:1;"
+         offset="0"
+         id="stop3902" />
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="1"
+         id="stop3904" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3906">
+      <stop
+         style="stop-color:#9e9e9e;stop-opacity:1;"
+         offset="0"
+         id="stop3908" />
+      <stop
+         id="stop3910"
+         offset="0.11111111"
+         style="stop-color:#c7c7c7;stop-opacity:0.990991;" />
+      <stop
+         style="stop-color:#eff0f1;stop-opacity:1;"
+         offset="1"
+         id="stop3912" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3928">
+      <stop
+         id="stop3930"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.97297299;" />
+      <stop
+         style="stop-color:#7f7f7f;stop-opacity:0.13513513;"
+         offset="0.5"
+         id="stop3936" />
+      <stop
+         id="stop3932"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3950">
+      <stop
+         style="stop-color:#2a78a0;stop-opacity:1;"
+         offset="0"
+         id="stop3952" />
+      <stop
+         style="stop-color:#eff0f1;stop-opacity:1;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3958">
+      <stop
+         id="stop3960"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3964"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3990">
+      <stop
+         id="stop3992"
+         offset="0"
+         style="stop-color:#287196;stop-opacity:1;" />
+      <stop
+         style="stop-color:#3394c5;stop-opacity:1;"
+         offset="0.13"
+         id="stop3998" />
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="0.41944444"
+         id="stop3996" />
+      <stop
+         id="stop3994"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4128">
+      <stop
+         style="stop-color:#287196;stop-opacity:1;"
+         offset="0"
+         id="stop4130" />
+      <stop
+         id="stop4132"
+         offset="0.13"
+         style="stop-color:#3394c5;stop-opacity:1;" />
+      <stop
+         id="stop4134"
+         offset="0.41999999"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="0.57999998"
+         id="stop4138" />
+      <stop
+         id="stop4140"
+         offset="0.78999996"
+         style="stop-color:#3394c5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#287196;stop-opacity:1;"
+         offset="1"
+         id="stop4136" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4197">
+      <stop
+         style="stop-color:#287196;stop-opacity:1;"
+         offset="0"
+         id="stop4199" />
+      <stop
+         style="stop-color:#287196;stop-opacity:1;"
+         offset="1"
+         id="stop4201" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4245">
+      <stop
+         id="stop4247"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.64313728;"
+         offset="0.5"
+         id="stop4261" />
+      <stop
+         id="stop4249"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.2882883;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4692">
+      <stop
+         id="stop4694"
+         offset="0"
+         style="stop-color:#c2c2c2;stop-opacity:1;" />
+      <stop
+         id="stop4696"
+         offset="1"
+         style="stop-color:#9e9e9e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867">
+      <stop
+         id="stop5869"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9123">
+      <stop
+         id="stop9125"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#9ed6f4;stop-opacity:1;"
+         offset="0.70652175"
+         id="stop9131" />
+      <stop
+         id="stop9127"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6426">
+      <stop
+         style="stop-color:#eff0f1;stop-opacity:1;"
+         offset="0"
+         id="stop6428" />
+      <stop
+         style="stop-color:#e7e8e9;stop-opacity:1;"
+         offset="1"
+         id="stop6430" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6450">
+      <stop
+         id="stop6452"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6454"
+         offset="1"
+         style="stop-color:#1998da;stop-opacity:1;" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146-1" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-3" />
+    <inkscape:perspective
+       id="perspective4090-8-3"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146-2" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-2" />
+    <inkscape:perspective
+       id="perspective4090-8-5"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146-9" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-5" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-89" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-9" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-0" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-29" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-1" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.576748"
+     inkscape:cx="16.113"
+     inkscape:cy="10.580645"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="1869"
+     inkscape:window-height="1060"
+     inkscape:window-x="49"
+     inkscape:window-y="-3"
+     inkscape:window-maximized="1"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <path
+       transform="translate(-1,1029.3622)"
+       style="color:#000000;fill:#b3b3b3;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 4,7.0000174 2.9989534,-3.0000002 14.0010466,0 0,12.9999998 -3,3 L 4,20 z"
+       id="rect4752"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       d="M 11 11 L 8 14 L 10 14 L 10 20 L 12 20 L 12 14 L 14 14 L 11 11 z "
+       transform="translate(-1,1029.3622)"
+       id="path5031-7" />
+    <path
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 6.96875 4 L 4 6.96875 L 4 8.40625 L 4 20 L 5 20 L 17 20 L 18 20 L 21 17 L 21 5 L 21 4.75 L 21 4.34375 L 21 4 L 8 4 L 6.96875 4 z M 7.40625 5 L 19.3125 5 L 17.3125 7 L 17 7 L 5.40625 7 L 7.40625 5 z M 20 5.75 L 20 16.5625 L 18 18.5625 L 18 7.75 L 20 5.75 z M 5 8 L 17 8 L 17 8.75 L 17 19 L 5 19 L 5 8 z "
+       transform="translate(-1,1029.3622)"
+       id="rect4530" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_fliphorizontal.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_fliphorizontal.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_colorsettings.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="13.330416"
+     inkscape:cy="15.694835"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="930"
+     inkscape:window-height="1053"
+     inkscape:window-x="51"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4128" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       transform="translate(0,1.738e-5)"
+       id="layer1-5"
+       inkscape:label="Capa 1">
+      <path
+         inkscape:connector-curvature="0"
+         id="rect4146"
+         d="m 16,1033.3622 0,1 -1,0 0,-1 1,0 z m -9,0 0,1 -1,0 0,-1 1,0 z m 9,2 0,1 3,0 0,10 -3,0 0,1 -1,0 0,-1 -3,0 0,-3 -2,0 0,3 -3,0 0,1 -1,0 0,-1 -3,0 0,-10 3,0 0,-1 1,0 0,1 3,0 0,3 2,0 0,-3 3,0 0,-1 1,0 z m 2,2 -5,0 0,8 5,0 0,-8 z m -9,0 -5,0 0,8 5,0 0,-8 z m 8,1 0,6 -3,0 0,-6 3,0 z m -5,2 -2,0 0,2 2,0 0,-2 z m 4,8 0,1 -1,0 0,-1 1,0 z m -9,0 0,1 -1,0 0,-1 1,0 z"
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_flipvertical.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_flipvertical.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_fliphorizontal.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="13.330416"
+     inkscape:cy="15.694835"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="930"
+     inkscape:window-height="1053"
+     inkscape:window-x="51"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4128" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       transform="translate(0,1.738e-5)"
+       id="layer1-1"
+       inkscape:label="Capa 1">
+      <path
+         inkscape:connector-curvature="0"
+         id="rect4146-2"
+         d="m 19,1046.3622 -1,0 0,-1 1,0 0,1 z m 0,-9 -1,0 0,-1 1,0 0,1 z m -2,9 -1,0 0,3 -10,0 0,-3 -1,0 0,-1 1,0 0,-3 3,0 0,-2 -3,0 0,-3 -1,0 0,-1 1,0 0,-3 10,0 0,3 1,0 0,1 -1,0 0,3 -3,0 0,2 3,0 0,3 1,0 0,1 z m -2,2 0,-5 -8,0 0,5 8,0 z m 0,-9 0,-5 -8,0 0,5 8,0 z m -1,8 -6,0 0,-3 6,0 0,3 z m -2,-5 0,-2 -2,0 0,2 2,0 z m -8,4 -1,0 0,-1 1,0 0,1 z m 0,-9 -1,0 0,-1 1,0 0,1 z"
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_flowchartshapes.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_flowchartshapes.svg
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_flowchartshapes_flowchart_predefined_process.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="24.674634"
+     inkscape:cx="16.189941"
+     inkscape:cy="11.769696"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="1269"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4128" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <rect
+       style="color:#000000;fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3804"
+       width="14"
+       height="14"
+       x="5"
+       y="5.0000172"
+       transform="translate(-1,1029.3622)" />
+    <rect
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3001"
+       width="16"
+       height="1"
+       x="4"
+       y="4.0000172"
+       transform="translate(-1,1029.3622)" />
+    <rect
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3771"
+       width="1"
+       height="15"
+       x="19"
+       y="5.0000172"
+       transform="translate(-1,1029.3622)" />
+    <rect
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3773"
+       width="1"
+       height="14.999983"
+       x="4"
+       y="5.0000172"
+       transform="translate(-1,1029.3622)" />
+    <rect
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3775"
+       width="14"
+       height="0.9999826"
+       x="5"
+       y="19.000017"
+       transform="translate(-1,1029.3622)" />
+    <rect
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3777"
+       width="1"
+       height="14"
+       x="9"
+       y="5.0000172"
+       transform="translate(-1,1029.3622)" />
+    <rect
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3779"
+       width="14"
+       height="1"
+       x="5"
+       y="9.0000172"
+       transform="translate(-1,1029.3622)" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_fontcolor.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_fontcolor.svg
@@ -1,0 +1,1 @@
+lc_color.svg

--- a/Breeze/actions/LO_lc_icons_breeze/lc_fontworkgalleryfloater.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_fontworkgalleryfloater.svg
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_drawcaption.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="6.9999886"
+       x2="26.21154"
+       y1="43.999989"
+       x1="26.21154"
+       id="linearGradient4416"
+       xlink:href="#linearGradient4435"
+       inkscape:collect="always"
+       gradientTransform="matrix(-1.4054053,0,0,1.4054053,804.69502,154.09579)" />
+    <linearGradient
+       gradientTransform="translate(0,-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="177.93361"
+       x2="768.85718"
+       y1="201.93361"
+       x1="768.85718"
+       id="linearGradient4179"
+       xlink:href="#linearGradient4344"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4400">
+      <stop
+         style="stop-color:#020303;stop-opacity:1"
+         offset="0"
+         id="stop4402" />
+      <stop
+         style="stop-color:#424649;stop-opacity:0"
+         offset="1"
+         id="stop4404" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="44"
+       x2="43.999996"
+       y1="19.999998"
+       x1="19.999998"
+       id="linearGradient4394"
+       xlink:href="#linearGradient4400"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4435">
+      <stop
+         style="stop-color:#c61423;stop-opacity:1"
+         offset="0"
+         id="stop4437" />
+      <stop
+         style="stop-color:#dc2b41;stop-opacity:1"
+         offset="1"
+         id="stop4439" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4344"
+       inkscape:collect="always">
+      <stop
+         id="stop4346"
+         offset="0"
+         style="stop-color:#ed868d;stop-opacity:1" />
+      <stop
+         id="stop4348"
+         offset="1"
+         style="stop-color:#fbe6e8;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="23.818182"
+     inkscape:cx="10.106903"
+     inkscape:cy="7.5023032"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1869"
+     inkscape:window-height="1060"
+     inkscape:window-x="49"
+     inkscape:window-y="-3"
+     inkscape:window-maximized="1"
+     units="px"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4085" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4087" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4089" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4091" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4093" />
+    <sodipodi:guide
+       position="2,4"
+       orientation="0,16"
+       id="guide4095" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4097" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4099" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4123" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,2.000001"
+       id="guide4125" />
+    <sodipodi:guide
+       position="5,20"
+       orientation="-16,0"
+       id="guide4127" />
+    <sodipodi:guide
+       position="6.000001,20"
+       orientation="0,-2.000001"
+       id="guide4129" />
+    <sodipodi:guide
+       position="19,20"
+       orientation="16,0"
+       id="guide4131" />
+    <sodipodi:guide
+       position="18,4"
+       orientation="0,2"
+       id="guide4133" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4135" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-2"
+       id="guide4137" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       id="layer1-3"
+       inkscape:label="Capa 1"
+       transform="translate(0,-0.999983)">
+      <g
+         inkscape:label="Capa 1"
+         id="layer1-2">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#ff6600;fill-opacity:1;stroke:none"
+           d="M 3,3 3,19 19,19 19,3 3,3 z M 5,5 17,5 17,17 5,17 5,5 z"
+           transform="translate(0,1030.3622)"
+           id="rect4112" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+           d="M 4,4 4,18 18,18 18,4 4,4 z M 5,5 17,5 17,17 5,17 5,5 z"
+           transform="translate(0,1030.3622)"
+           id="rect4114" />
+      </g>
+    </g>
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;font-family:Oxygen;-inkscape-font-specification:Oxygen"
+       d="M 11 6 L 7 16 L 8.375 16 L 9.6875 13 L 14.40625 13 L 15.625 16 L 17 16 L 13 6 L 11 6 z M 12 7 L 14 12 L 10 12 L 12 7 z "
+       transform="translate(-1,1029.3622)"
+       id="path4149-5" />
+    <g
+       transform="translate(-551.28571,421.71431)"
+       id="layer1-1"
+       inkscape:label="Capa 1" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_formatarea.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_formatarea.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_lineendstyle.svg">
+  <defs
+     id="defs3762" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="34.579357"
+     inkscape:cx="12.13631"
+     inkscape:cy="11.173086"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1167"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="21.000014,2.9999782"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="6,0"
+       id="guide4155" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4167" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <g
+       transform="translate(551.28573,-422.71429)"
+       id="layer1-2"
+       inkscape:label="Capa 1">
+      <path
+         id="rect4108"
+         transform="translate(0,1030.3622)"
+         d="M 5.5,3 C 5.013545,4.7025 3.8218,6.1660906 3.296875,7.3378906 3.113175,7.6862906 3,8.0773 3,8.5 3,9.885 4.115,11 5.5,11 6.885,11 8,9.885 8,8.5 8,8.0773 7.886825,7.6862906 7.703125,7.3378906 7.1782,6.1660906 5.98645,4.7025 5.5,3 z m 11,0 C 16.013545,4.7025 14.8218,6.1660906 14.296875,7.3378906 14.113175,7.6862906 14,8.0773 14,8.5 14,9.885 15.115,11 16.5,11 17.885,11 19,9.885 19,8.5 19,8.0773 18.886825,7.6862906 18.703125,7.3378906 18.1782,6.1660906 16.98645,4.7025 16.5,3 z M 11,11 C 10.513545,12.7025 9.3218,14.166091 8.796875,15.337891 8.613175,15.686291 8.5,16.0773 8.5,16.5 c 0,1.385 1.115,2.5 2.5,2.5 1.385,0 2.5,-1.115 2.5,-2.5 0,-0.4227 -0.113175,-0.813709 -0.296875,-1.162109 C 12.6782,14.166091 11.48645,12.7025 11,11 z"
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_formatgroup.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_formatgroup.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_formatungroup.svg">
+  <defs
+     id="defs3762">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="18.948032"
+     inkscape:cy="10.686706"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-8"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1371"
+     inkscape:window-height="1053"
+     inkscape:window-x="51"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="21.000014,2.9999782"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4167" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <g
+       transform="translate(129.57144,81.85715)"
+       id="layer1-8"
+       inkscape:label="Capa 1">
+      <path
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+         d="m 424.71427,528.79074 0,16 16,0 0,-16 -16,0 z m 1,1 14,0 0,3 0,11 -14,0 0,-11 0,-3 z"
+         id="rect4089"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="path4310"
+         sodipodi:cx="9.0000191"
+         sodipodi:cy="9.0000172"
+         sodipodi:rx="3"
+         sodipodi:ry="3"
+         d="m 12.000019,9.0000172 a 3,3 0 1 1 -5.9999999,0 3,3 0 1 1 5.9999999,0 z"
+         transform="matrix(0.83333331,0,0,0.83333331,421.71427,525.79074)" />
+      <rect
+         style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4312"
+         width="5"
+         height="4.9999857"
+         x="433.71429"
+         y="530.79077" />
+      <rect
+         style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4314"
+         width="2.9999998"
+         height="5"
+         x="427.71429"
+         y="537.79077" />
+      <path
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+         d="m 433.71429,542.79076 2.5,-5 2.5,5 z"
+         id="path4316"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_formatline.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_formatline.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_fillstyle.svg">
+  <defs
+     id="defs3762" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="17.289679"
+     inkscape:cx="8.4672724"
+     inkscape:cy="20.059224"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1167"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="21.000014,2.9999782"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="6,0"
+       id="guide4155" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4167" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       d="m 563.2818,610.6479 -7.32617,7.32617 -0.002,-0.004 -1.41406,1.41407 0.002,0.004 -0.25,0.25 -0.006,0 0,4.00781 1,0 2,0 1.00781,0 0.25196,-0.25195 0.35351,-0.35352 0.70703,-0.70703 0.35547,-0.35352 7.32227,-7.33007 -3.99805,-4 z m -0.58398,1.9961 2.58789,2.58984 -4.26758,4.26758 -2.58789,-2.58985 z m -4.97461,4.97461 2.58789,2.58984 -0.70703,0.70703 -2.58984,-2.58984 0.27343,-0.27149 z m -1.41602,1.41406 2.58985,2.58984 0.004,0.002 -0.70703,0.70703 -0.004,-0.002 -2.58985,-2.58984 z m -2.02148,6.61328 0,1 16,0 0,-1 z"
+       id="rect4112"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccc" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_formatungroup.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_formatungroup.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_formatungroup.svg">
+  <defs
+     id="defs3762">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="64"
+     inkscape:cx="15.78486"
+     inkscape:cy="10.701631"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-8"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1869"
+     inkscape:window-height="1060"
+     inkscape:window-x="49"
+     inkscape:window-y="-3"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="21.000014,2.9999782"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4167" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <g
+       transform="translate(129.57144,81.85715)"
+       id="layer1-8"
+       inkscape:label="Capa 1">
+      <path
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+         d="M 4 4 L 4 8 L 5 8 L 5 5 L 8 5 L 8 4 L 4 4 z M 16 4 L 16 5 L 19 5 L 19 8 L 20 8 L 20 4 L 16 4 z M 4 16 L 4 20 L 8 20 L 8 19 L 5 19 L 5 16 L 4 16 z M 19 16 L 19 19 L 16 19 L 16 20 L 20 20 L 20 16 L 19 16 z "
+         transform="translate(420.71427,524.79074)"
+         id="rect4089" />
+      <path
+         sodipodi:type="arc"
+         style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="path4310"
+         sodipodi:cx="9.0000191"
+         sodipodi:cy="9.0000172"
+         sodipodi:rx="3"
+         sodipodi:ry="3"
+         d="m 12.000019,9.0000172 a 3,3 0 1 1 -5.9999999,0 3,3 0 1 1 5.9999999,0 z"
+         transform="matrix(0.83333331,0,0,0.83333331,421.71427,525.79074)" />
+      <rect
+         style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4312"
+         width="5"
+         height="4.9999857"
+         x="433.71429"
+         y="530.79077" />
+      <rect
+         style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect4314"
+         width="2.9999998"
+         height="5"
+         x="427.71429"
+         y="537.79077" />
+      <path
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+         d="m 433.71429,542.79076 2.5,-5 2.5,5 z"
+         id="path4316"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_framedialog.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_framedialog.svg
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_rotateright.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.625"
+     inkscape:cx="11.546798"
+     inkscape:cy="5.1076832"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1252"
+     inkscape:window-height="1053"
+     inkscape:window-x="51"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4066" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4068" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4070" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4072" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4074" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4076" />
+    <sodipodi:guide
+       position="20,14.999983"
+       orientation="-16,0"
+       id="guide4078" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4080" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="9,20"
+       orientation="0,-5"
+       id="guide4124" />
+    <sodipodi:guide
+       position="12,4"
+       orientation="0,4"
+       id="guide4241" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <path
+       style="fill:#ff6600;fill-opacity:1;stroke:none"
+       d="M 4 4 L 4 20 L 9 20 L 9 18 L 6 18 L 6 6 L 18 6 L 18 17 L 20 17 L 20 4 L 4 4 z "
+       transform="translate(-1,1029.3622)"
+       id="rect4112" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       d="M 5 5 L 5 19 L 9 19 L 9 18 L 6 18 L 6 6 L 18 6 L 18 17 L 19 17 L 19 5 L 5 5 z "
+       transform="translate(-1,1029.3622)"
+       id="rect4114" />
+    <path
+       style="opacity:0.98692812;color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 10.90625 18 A 1 1 0 0 0 10 19 A 1 1 0 0 0 11 20 A 1 1 0 0 0 12 19 A 1 1 0 0 0 11 18 A 1 1 0 0 0 10.90625 18 z M 14.90625 18 A 1 1 0 0 0 14 19 A 1 1 0 0 0 15 20 A 1 1 0 0 0 16 19 A 1 1 0 0 0 15 18 A 1 1 0 0 0 14.90625 18 z M 18.90625 18 A 1 1 0 0 0 18 19 A 1 1 0 0 0 19 20 A 1 1 0 0 0 20 19 A 1 1 0 0 0 19 18 A 1 1 0 0 0 18.90625 18 z "
+       transform="translate(-1,1029.3622)"
+       id="rect3016" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_framelinecolor.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_framelinecolor.svg
@@ -11,13 +11,12 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="24"
    height="24"
-   id="svg2"
+   id="svg3760"
    version="1.1"
-   inkscape:version="0.91+devel r"
-   viewBox="0 0 24 24"
+   inkscape:version="0.48.4 r9939"
    sodipodi:docname="lc_framelinecolor.svg">
   <defs
-     id="defs4" />
+     id="defs3762" />
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -25,72 +24,77 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="32.625"
-     inkscape:cx="11.710291"
-     inkscape:cy="12.980759"
+     inkscape:zoom="33.91186"
+     inkscape:cx="14.638624"
+     inkscape:cy="11.584707"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     units="px"
-     borderlayer="true"
-     inkscape:showpageshadow="false"
-     inkscape:window-width="1366"
-     inkscape:window-height="670"
-     inkscape:window-x="-4"
-     inkscape:window-y="29"
-     inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
-     fit-margin-bottom="0">
+     fit-margin-bottom="0"
+     inkscape:window-width="1869"
+     inkscape:window-height="1060"
+     inkscape:window-x="49"
+     inkscape:window-y="-3"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="false"
+     inkscape:snap-bbox="true">
     <sodipodi:guide
-       position="3,21"
+       position="-1.4433594e-05,24.000012"
+       orientation="24,0"
+       id="guide4115" />
+    <sodipodi:guide
+       position="-1.4433594e-05,1.1816406e-05"
+       orientation="0,24"
+       id="guide4117" />
+    <sodipodi:guide
+       position="23.999986,1.1816406e-05"
+       orientation="-24,0"
+       id="guide4119" />
+    <sodipodi:guide
+       position="23.999986,24.000012"
+       orientation="0,-24"
+       id="guide4121" />
+    <sodipodi:guide
+       position="2.9999856,21.000012"
        orientation="18,0"
-       id="guide4066" />
+       id="guide4123" />
     <sodipodi:guide
-       position="3,3"
+       position="2.9999856,3.0000118"
        orientation="0,18"
-       id="guide4068" />
+       id="guide4125" />
     <sodipodi:guide
-       position="21,3"
+       position="20.999986,3.0000118"
        orientation="-18,0"
-       id="guide4070" />
+       id="guide4127" />
     <sodipodi:guide
-       position="21,21"
+       position="20.999986,21.000012"
        orientation="0,-18"
-       id="guide4072" />
+       id="guide4129" />
     <sodipodi:guide
-       position="4,20"
+       position="3.9999856,20.000012"
        orientation="16,0"
-       id="guide4074" />
+       id="guide4131" />
     <sodipodi:guide
-       position="4,4"
+       position="3.9999856,4.0000118"
        orientation="0,16"
-       id="guide4076" />
+       id="guide4133" />
     <sodipodi:guide
-       position="20,4"
+       position="19.999986,4.0000118"
        orientation="-16,0"
-       id="guide4078" />
+       id="guide4135" />
     <sodipodi:guide
-       position="20,20"
+       position="19.999986,20.000012"
        orientation="0,-16"
-       id="guide4080" />
+       id="guide4137" />
     <inkscape:grid
        type="xygrid"
-       id="grid4101"
-       originx="1px"
-       originy="0.99998262px" />
-    <sodipodi:guide
-       position="9,20"
-       orientation="0,-5"
-       id="guide4124" />
-    <sodipodi:guide
-       position="12,4"
-       orientation="0,4"
-       id="guide4241" />
+       id="grid4139" />
   </sodipodi:namedview>
   <metadata
-     id="metadata7">
+     id="metadata3765">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -105,19 +109,21 @@
      inkscape:label="Capa 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(1,-1029.3622)">
+     transform="translate(-550.28572,-606.6479)">
     <path
-       style="opacity:1;fill:#ff6600;fill-opacity:1;stroke:none"
-       d="M 4 4 L 4 20 L 11 20 L 11 18 L 6 18 L 6 6 L 18 6 L 18 11 L 20 11 L 20 4 L 4 4 z "
-       transform="translate(-1,1029.3622)"
-       id="rect4112" />
+       inkscape:connector-curvature="0"
+       style="fill:#ff6600;fill-opacity:1;stroke:none"
+       d="m 554.28572,610.64789 0,16 15.99999,1e-5 0,-2 -13.99999,-1e-5 0,-12 12,0 0,12.00001 1.99999,0 10e-6,-14.00001 z"
+       id="rect4112"
+       sodipodi:nodetypes="ccccccccccc" />
     <path
-       style="opacity:1;fill:#4d4d4d;fill-opacity:1;stroke:none"
-       d="M 5 5 L 5 19 L 11 19 L 11 18 L 6 18 L 6 6 L 18 6 L 18 11 L 19 11 L 19 5 L 5 5 z "
-       transform="translate(-1,1029.3622)"
-       id="rect4114" />
+       inkscape:connector-curvature="0"
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       d="m 555.28572,611.64789 0,14 14,1e-5 -1,-1 -12,-1e-5 0,-12 12,0 0,12.00001 1,1 0,-14.00001 z"
+       id="rect4114"
+       sodipodi:nodetypes="ccccccccccc" />
     <g
-       transform="translate(-579.26079,421.36228)"
+       transform="translate(-30.47507,-3.85202)"
        id="layer1-1"
        inkscape:label="Capa 1">
       <path
@@ -125,7 +131,7 @@
          inkscape:connector-curvature="0"
          id="rect4112-6"
          d="m 595.76079,619.99992 c -0.48646,1.7025 -1.6782,3.16609 -2.20313,4.33789 -0.1837,0.3484 -0.29687,0.73941 -0.29687,1.16211 0,1.385 1.115,2.5 2.5,2.5 1.385,0 2.5,-1.115 2.5,-2.5 0,-0.4227 -0.11317,-0.81371 -0.29688,-1.16211 -0.52491,-1.1718 -1.71667,-2.63539 -2.20312,-4.33789 z"
-         style="opacity:1;fill:#4d4d4d;fill-opacity:1;stroke:none" />
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none" />
     </g>
   </g>
 </svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_freeline_unfilled.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_freeline_unfilled.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_freeline.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       id="perspective4090"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="25.15656"
+     inkscape:cx="6.4702358"
+     inkscape:cy="4.2195907"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="1195"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4128" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       d="m 12,1033.3622 -7.34375,7.3125 -1.40625,1.4375 -0.25,0.25 0,4 1,0 2,0 1,0 0.25,-0.25 0.375,-0.3437 0.6875,-0.7188 0.375,-0.3437 6.3125,-6.3438 1,-1 -4,-4 z m -0.59375,2 2.59375,2.5938 -4.28125,4.25 -2.5625,-2.5938 4.25,-4.25 z m -4.96875,4.9688 2.59375,2.5937 -0.71875,0.7188 -2.59375,-2.5938 L 6,1040.7685 6.4375,1040.331 z m -1.40625,1.4062 2.59375,2.5938 -0.71875,0.7187 -2.59375,-2.5937 0.71875,-0.7188 z"
+       id="rect4112" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 16.498545,1044.3622 c -0.26168,10e-4 -0.95438,0.046 -2.0625,0.5625 -0.34642,0.1616 -0.63562,0.3445 -1.03125,0.5625 -0.2112,0.1164 -0.96821,0.4943 -1.25,0.625 -0.82575,0.3832 -1.09998,0.4799 -1.8125,0.75 -0.6895696,0.2615 -1.4331096,0.4987 -1.9374996,0.6875 -2.12309,0.7948 -5.40625,0.8125 -5.40625,0.8125 l 0,1 c 0,0 3.32719,0.032 5.75,-0.875 0.32138,-0.1203 0.88143,-0.3176 1.4062496,-0.5 0,0 2.4806,0.7629 4.34375,1.1563 1.5254,0.412 2.70037,0.1486 3.28125,-0.1563 0.83679,-0.4772 1.24797,-1.3364 1.21875,-2.1562 -0.005,-0.2879 -0.0772,-0.5251 -0.21875,-0.8438 -0.14159,-0.3186 -0.344,-0.6761 -0.65625,-0.9375 -0.4819,-0.4232 -0.72357,-0.6094 -1.625,-0.6875 z m 0,1 c -0.0448,2e-4 0.17377,0.01 0.375,0.094 0.20123,0.084 0.42477,0.2336 0.59375,0.375 0.32735,0.3319 0.46461,0.5852 0.53125,1.0313 -0.0257,0.682 -0.26059,0.8957 -0.75,1.2812 -0.64594,0.4279 -1.81904,0.1531 -2.5625,0.031 -1.26282,-0.2666 -2.17759,-0.5362 -3,-0.7812 0.26097,-0.109 0.48139,-0.1924 0.875,-0.375 0.30467,-0.1414 1.01284,-0.4911 1.3125,-0.6563 0.44025,-0.2426 0.73379,-0.4217 0.96875,-0.5312 0.51342,-0.3024 1.08335,-0.4823 1.65625,-0.4687 z"
+       id="path3826"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccsccc" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_graphicfiltertoolbox.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_graphicfiltertoolbox.svg
@@ -1,0 +1,1 @@
+lc_autoformat.svg

--- a/Breeze/actions/LO_lc_icons_breeze/lc_line.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_line.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_line.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="33.683996"
+     inkscape:cx="16.735337"
+     inkscape:cy="8.8868736"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1473"
+     inkscape:window-height="1042"
+     inkscape:window-x="443"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     units="px"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4085" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4087" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4089" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4091" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4093" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4095" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4097" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4099" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4123" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,2.000001"
+       id="guide4125" />
+    <sodipodi:guide
+       position="5,20"
+       orientation="-16,0"
+       id="guide4127" />
+    <sodipodi:guide
+       position="6.000001,20"
+       orientation="0,-2.000001"
+       id="guide4129" />
+    <sodipodi:guide
+       position="19,20"
+       orientation="16,0"
+       id="guide4131" />
+    <sodipodi:guide
+       position="18,4"
+       orientation="0,2"
+       id="guide4133" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4135" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-2"
+       id="guide4137" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <rect
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect3026"
+       width="16"
+       height="2"
+       x="4"
+       y="11.000017"
+       transform="translate(-1,1029.3622)" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_lineendstyle.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_lineendstyle.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_lineendstyle.svg">
+  <defs
+     id="defs3762" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="34.579357"
+     inkscape:cx="12.13631"
+     inkscape:cy="11.173086"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1167"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="21.000014,2.9999782"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="6,0"
+       id="guide4155" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4167" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       d="m 557.28571,612.64789 0,2 13,0 0,2 -13,0 0,2 -3,-3 3,-3 z"
+       id="path5031-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       d="M 17 12 C 15.698679 12 14.60301 12.841652 14.1875 14 L 4 14 L 4 16 L 14.1875 16 C 14.60301 17.158348 15.698679 18 17 18 C 18.656854 18 20 16.656854 20 15 C 20 13.343146 18.656854 12 17 12 z "
+       transform="translate(550.28571,606.64789)"
+       id="path5031-7-1" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_ok.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_ok.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_ok.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.625"
+     inkscape:cx="5.9329091"
+     inkscape:cy="12.64122"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1252"
+     inkscape:window-height="1053"
+     inkscape:window-x="51"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4066" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4068" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4070" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4072" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4074" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4076" />
+    <sodipodi:guide
+       position="20,14.999983"
+       orientation="-16,0"
+       id="guide4078" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4080" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="9,20"
+       orientation="0,-5"
+       id="guide4124" />
+    <sodipodi:guide
+       position="12,4"
+       orientation="0,4"
+       id="guide4241" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       id="layer1-6"
+       inkscape:label="Capa 1">
+      <g
+         transform="translate(0,-9.9999997e-6)"
+         inkscape:label="Capa 1"
+         id="layer1-0">
+        <g
+           transform="translate(-364.57143,504.57146)"
+           id="layer1-9"
+           inkscape:label="Capa 1">
+          <path
+             inkscape:connector-curvature="0"
+             id="rect4113"
+             d="m 382.8643,530.79077 -10.43876,10.56644 -4.14699,-4.19772 -0.70712,0.71578 4.14699,4.1977 -0.002,0.002 0.70713,0.71577 0.002,-0.002 0.002,0.002 0.70711,-0.71577 -0.002,-0.002 10.43877,-10.56645 -0.70712,-0.71576 z"
+             style="fill:#4d4d4d;fill-opacity:1;stroke:none" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_rect.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_rect.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_selectall.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       id="perspective4090"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="25.15656"
+     inkscape:cx="12.890504"
+     inkscape:cy="15.114787"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="1195"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4128" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       id="layer1-8"
+       inkscape:label="Capa 1"
+       transform="translate(0,3.4762812e-5)">
+      <rect
+         y="1035.3622"
+         x="3"
+         height="12"
+         width="16"
+         id="rect4603"
+         style="opacity:0.98692812;color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_rotateleft.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_rotateleft.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_graphicfiltertoolbox.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="23.069359"
+     inkscape:cx="14.941807"
+     inkscape:cy="4.6557698"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1252"
+     inkscape:window-height="1053"
+     inkscape:window-x="51"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4066" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4068" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4070" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4072" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4074" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4076" />
+    <sodipodi:guide
+       position="20,14.999983"
+       orientation="-16,0"
+       id="guide4078" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4080" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="9,20"
+       orientation="0,-5"
+       id="guide4124" />
+    <sodipodi:guide
+       position="12,4"
+       orientation="0,4"
+       id="guide4241" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       id="layer1-1"
+       inkscape:label="Capa 1">
+      <path
+         id="rect4144"
+         transform="translate(0,1030.3622)"
+         d="M 12.400391,3 9.1074219,6.2929688 8.9003906,6.5 9.1074219,6.7070312 12.400391,10 13.107422,9.2929688 10.814453,7 13.099609,7 14,7 14,6 13.099609,6 10.814453,6 13.107422,3.7070312 12.400391,3 z M 15.5,6 C 15.223,6 15,6.223 15,6.5 15,6.777 15.223,7 15.5,7 15.777,7 16,6.777 16,6.5 16,6.223 15.777,6 15.5,6 z M 6.9492188,8 2,12.949219 8.0507812,19 13,14.050781 6.9492188,8 z M 18.5,8 C 18.223,8 18,8.223 18,8.5 18,8.777 18.223,9 18.5,9 18.777,9 19,8.777 19,8.5 19,8.223 18.777,8 18.5,8 z M 6.9492188,9.4140625 11.726562,14.191406 8.1914062,17.726562 3.4140625,12.949219 6.9492188,9.4140625 z M 19.5,11 C 19.223,11 19,11.223 19,11.5 19,11.777 19.223,12 19.5,12 19.777,12 20,11.777 20,11.5 20,11.223 19.777,11 19.5,11 z m -1,3 C 18.223,14 18,14.223 18,14.5 18,14.777 18.223,15 18.5,15 18.777,15 19,14.777 19,14.5 19,14.223 18.777,14 18.5,14 z m -3,2 C 15.223,16 15,16.223 15,16.5 15,16.777 15.223,17 15.5,17 15.777,17 16,16.777 16,16.5 16,16.223 15.777,16 15.5,16 z"
+         style="text-decoration:none;color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_rotateright.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_rotateright.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_rotateleft.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="23.069359"
+     inkscape:cx="14.941807"
+     inkscape:cy="4.6557698"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1252"
+     inkscape:window-height="1053"
+     inkscape:window-x="51"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4066" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4068" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4070" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4072" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4074" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4076" />
+    <sodipodi:guide
+       position="20,14.999983"
+       orientation="-16,0"
+       id="guide4078" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4080" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="9,20"
+       orientation="0,-5"
+       id="guide4124" />
+    <sodipodi:guide
+       position="12,4"
+       orientation="0,4"
+       id="guide4241" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       id="layer1-8"
+       inkscape:label="Capa 1">
+      <path
+         inkscape:connector-curvature="0"
+         id="rect4144-9"
+         d="m 9.599609,1033.3622 3.292969,3.293 0.207031,0.207 -0.207031,0.207 -3.292969,3.293 -0.707031,-0.707 2.292969,-2.293 -2.285156,0 -0.900391,0 0,-1 0.900391,0 2.285156,0 -2.292969,-2.293 0.707031,-0.707 z m -3.099609,3 c 0.277,0 0.5,0.223 0.5,0.5 0,0.277 -0.223,0.5 -0.5,0.5 -0.277,0 -0.5,-0.223 -0.5,-0.5 0,-0.277 0.223,-0.5 0.5,-0.5 z m 8.550781,2 L 20,1043.3114 13.949219,1049.3622 9,1044.413 l 6.050781,-6.0508 z m -11.550781,0 c 0.277,0 0.5,0.223 0.5,0.5 0,0.277 -0.223,0.5 -0.5,0.5 -0.277,0 -0.5,-0.223 -0.5,-0.5 0,-0.277 0.223,-0.5 0.5,-0.5 z m 11.550781,1.4141 -4.777343,4.7773 3.535156,3.5352 4.777343,-4.7774 -3.535156,-3.5351 z M 2.5,1041.3622 c 0.277,0 0.5,0.223 0.5,0.5 0,0.277 -0.223,0.5 -0.5,0.5 -0.277,0 -0.5,-0.223 -0.5,-0.5 0,-0.277 0.223,-0.5 0.5,-0.5 z m 1,3 c 0.277,0 0.5,0.223 0.5,0.5 0,0.277 -0.223,0.5 -0.5,0.5 -0.277,0 -0.5,-0.223 -0.5,-0.5 0,-0.277 0.223,-0.5 0.5,-0.5 z m 3,2 c 0.277,0 0.5,0.223 0.5,0.5 0,0.277 -0.223,0.5 -0.5,0.5 -0.277,0 -0.5,-0.223 -0.5,-0.5 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+         style="text-decoration:none;color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_selectobject.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_selectobject.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_line.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="33.683996"
+     inkscape:cx="13.024376"
+     inkscape:cy="11.261889"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1473"
+     inkscape:window-height="1042"
+     inkscape:window-x="161"
+     inkscape:window-y="41"
+     inkscape:window-maximized="0"
+     units="px"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4085" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4087" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4089" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4091" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4093" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4095" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4097" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4099" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4123" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,2.000001"
+       id="guide4125" />
+    <sodipodi:guide
+       position="5,20"
+       orientation="-16,0"
+       id="guide4127" />
+    <sodipodi:guide
+       position="6.000001,20"
+       orientation="0,-2.000001"
+       id="guide4129" />
+    <sodipodi:guide
+       position="19,20"
+       orientation="16,0"
+       id="guide4131" />
+    <sodipodi:guide
+       position="18,4"
+       orientation="0,2"
+       id="guide4133" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4135" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-2"
+       id="guide4137" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <g
+       transform="translate(-461.71429,504.57145)"
+       id="layer1-1"
+       inkscape:label="Capa 1">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path4147"
+         transform="translate(461.71429,525.79075)"
+         d="M 6,3 6,17 8.8721328,15.172524 13,19 12.299867,13.799477 16,13 z"
+         style="fill:#4d4d4d;fill-rule:evenodd;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_starshapes.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_starshapes.svg
@@ -1,0 +1,3900 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_flowchartshapes_flowchart_preparation.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       id="perspective4090"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4146"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-8" />
+    <linearGradient
+       y2="147.25354"
+       x2="-160.9847"
+       y1="115.75639"
+       x1="-160.9847"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10051"
+       xlink:href="#linearGradient6004"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6004-0">
+      <stop
+         id="stop6006-2"
+         offset="0"
+         style="stop-color:#5a646e;stop-opacity:1;" />
+      <stop
+         id="stop6008-8"
+         offset="1"
+         style="stop-color:#475057;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="147.25354"
+       x2="-160.9847"
+       y1="115.75639"
+       x1="-160.9847"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6416-0"
+       xlink:href="#linearGradient6004-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6346"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4948">
+      <stop
+         id="stop4950"
+         offset="0"
+         style="stop-color:#5a646e;stop-opacity:1;" />
+      <stop
+         id="stop4952"
+         offset="1"
+         style="stop-color:#475057;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="147.25354"
+       x2="-160.9847"
+       y1="115.75639"
+       x1="-160.9847"
+       gradientTransform="translate(0.01553073,0.49882594)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6108"
+       xlink:href="#linearGradient6004"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-22-8-9">
+      <stop
+         id="stop3858-16-1-9"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857-9-8"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-22-8-9"
+       id="linearGradient7385-8-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       x1="634.62195"
+       y1="524.59497"
+       x2="639.1156"
+       y2="524.59497" />
+    <linearGradient
+       id="linearGradient4913">
+      <stop
+         id="stop4915"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4917"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4911"
+       xlink:href="#linearGradient4560-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4905">
+      <stop
+         id="stop4907"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4909"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4898">
+      <stop
+         id="stop4900"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4902"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7891-4"
+       xlink:href="#linearGradient3856-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4891">
+      <stop
+         id="stop4893"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4895"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7887-6"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4884">
+      <stop
+         id="stop4886"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4888"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7885-5"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4877">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7889-8"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-4-2">
+      <stop
+         id="stop3858-5-3"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-7-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="translate(-153.98289,90.060334)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7883-8"
+       xlink:href="#linearGradient3856-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4866">
+      <stop
+         id="stop4868"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4870"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4864"
+       xlink:href="#linearGradient4560-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4560-9">
+      <stop
+         id="stop4562-2"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4564-4"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4850">
+      <stop
+         id="stop4852"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4854"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4848"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4842">
+      <stop
+         id="stop4844"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4846"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6295"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4783">
+      <stop
+         id="stop4785"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4787"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4781"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-2-1">
+      <stop
+         id="stop3858-6-5"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-4"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5991"
+       xlink:href="#linearGradient3856-2-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-22-3-1">
+      <stop
+         id="stop3858-16-8-9"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857-0-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5989"
+       xlink:href="#linearGradient3856-22-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6004">
+      <stop
+         id="stop6006"
+         offset="0"
+         style="stop-color:#5a646e;stop-opacity:1;" />
+      <stop
+         id="stop6008"
+         offset="1"
+         style="stop-color:#475057;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="147.25354"
+       x2="-160.9847"
+       y1="115.75639"
+       x1="-160.9847"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6093"
+       xlink:href="#linearGradient6004"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5117"
+       xlink:href="#linearGradient3856-22"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="matrix(1.0005238,0,0,0.91257347,-101.00421,8.4946302)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5093"
+       xlink:href="#linearGradient3856-6-78-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.58937"
+       x2="543.96741"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.73829795,0,0,0.91833374,-103.78254,170.81814)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5091"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7523"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7521"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-22-82"
+       id="linearGradient7385-81"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       x1="634.62195"
+       y1="524.59497"
+       x2="639.1156"
+       y2="524.59497" />
+    <linearGradient
+       id="linearGradient3856-22-82">
+      <stop
+         id="stop3858-16-89"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857-07"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8274-2"
+       xlink:href="#linearGradient3856-22-82"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-22-8">
+      <stop
+         id="stop3858-16-1"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8274-6"
+       xlink:href="#linearGradient3856-22-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-22-3">
+      <stop
+         id="stop3858-16-8"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857-0"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="matrix(1.1126725,0,0,1,760.07872,180.44984)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8274-4"
+       xlink:href="#linearGradient3856-22-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-6-78-8-96">
+      <stop
+         id="stop3858-71-3-29-5"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5-10"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-78-8-89">
+      <stop
+         id="stop3858-71-3-29-84"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5-1"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-3">
+      <stop
+         id="stop3858-51"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-201"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1029.3622"
+       x2="1061.5686"
+       y1="1029.3622"
+       x1="1014.0001"
+       id="linearGradient6710-8"
+       xlink:href="#linearGradient3856-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6672">
+      <stop
+         id="stop6674"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6676"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5710-0"
+       xlink:href="#linearGradient3856-60"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6665">
+      <stop
+         id="stop6667"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6669"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6658">
+      <stop
+         id="stop6660"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6662"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6651">
+      <stop
+         id="stop6653"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6655"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6644">
+      <stop
+         id="stop6646"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6648"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6637">
+      <stop
+         id="stop6639"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6641"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6630">
+      <stop
+         id="stop6632"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6634"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6623">
+      <stop
+         id="stop6625"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6627"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6616">
+      <stop
+         id="stop6618"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6620"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-60">
+      <stop
+         id="stop3858-165"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-75"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6558">
+      <stop
+         id="stop6560"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6562"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="659.23761"
+       x2="1262.1884"
+       y1="659.23761"
+       x1="1259.8062"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7805-0"
+       xlink:href="#linearGradient3856-11-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-11-5">
+      <stop
+         id="stop3858-61-4"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-97-2"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5997">
+      <stop
+         id="stop5999"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6001"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7887-4"
+       xlink:href="#linearGradient3856-13"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5990">
+      <stop
+         id="stop5992"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop5994"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-13">
+      <stop
+         id="stop3858-8"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-93"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5867-40-6"
+       id="linearGradient5681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3144.7365,-68.655864)"
+       x1="-327.40073"
+       y1="138.68115"
+       x2="-281.86459"
+       y2="138.68115" />
+    <linearGradient
+       id="linearGradient5673">
+      <stop
+         id="stop5675"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5677"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5867-40-6"
+       id="linearGradient5671"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(679.2638,226.89)"
+       x1="-327.40073"
+       y1="138.68115"
+       x2="-281.86459"
+       y2="138.68115" />
+    <linearGradient
+       id="linearGradient5867-40-6">
+      <stop
+         id="stop5869-9-8"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-48-5"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5867-40-6"
+       id="linearGradient8009-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(679.2638,226.89)"
+       x1="-327.40073"
+       y1="138.68115"
+       x2="-281.86459"
+       y2="138.68115" />
+    <linearGradient
+       id="linearGradient5522">
+      <stop
+         id="stop5524"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5526"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,176)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5520"
+       xlink:href="#linearGradient5867-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-1">
+      <stop
+         id="stop5869-52"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-7"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,176)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7951-71"
+       xlink:href="#linearGradient5867-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7025-7">
+      <stop
+         id="stop7027-7"
+         offset="0"
+         style="stop-color:#232629;stop-opacity:0.3137255;" />
+      <stop
+         id="stop7029-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7025-7"
+       id="linearGradient4385-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99886918,0,0,0.89231233,-282.01404,100.04625)"
+       x1="-51.551456"
+       y1="669.02393"
+       x2="-51.551456"
+       y2="671.74512" />
+    <linearGradient
+       id="linearGradient7025">
+      <stop
+         id="stop7027"
+         offset="0"
+         style="stop-color:#232629;stop-opacity:0.3137255;" />
+      <stop
+         id="stop7029"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="671.74512"
+       x2="-51.551456"
+       y1="669.02393"
+       x1="-51.551456"
+       gradientTransform="matrix(0.99886918,0,0,0.89231233,-282.01404,96.046246)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7134"
+       xlink:href="#linearGradient7025"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8077">
+      <stop
+         id="stop8079"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop8081"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-22">
+      <stop
+         id="stop3858-16"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-857"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5867-40"
+       id="linearGradient8009"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(679.2638,226.89)"
+       x1="-327.40073"
+       y1="138.68115"
+       x2="-281.86459"
+       y2="138.68115" />
+    <linearGradient
+       id="linearGradient8001">
+      <stop
+         id="stop8003"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop8005"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,176)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7999"
+       xlink:href="#linearGradient5867-40"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-40">
+      <stop
+         id="stop5869-9"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-48"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,176)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7951-7"
+       xlink:href="#linearGradient5867-40"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(0,176)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7951"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7893"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7889"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7881"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="920.40436"
+       x2="2397.3689"
+       y1="920.40436"
+       x1="2284.8362"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13430"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-6-78-8-8">
+      <stop
+         id="stop3858-71-3-29-4"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5-0"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="287.44943"
+       x2="-371.23654"
+       y1="287.44943"
+       x1="-387.84259"
+       id="linearGradient13238"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-6-78-8-9-0">
+      <stop
+         id="stop3858-71-3-29-8-8"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5-6-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="matrix(1.0005238,0,0,0.91257347,-102.10589,8.4074)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11658-6-2"
+       xlink:href="#linearGradient3856-6-78-8-9-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-6-78-8-9">
+      <stop
+         id="stop3858-71-3-29-8"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5-6"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13045"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13041"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13033"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="287.44943"
+       x2="-371.23654"
+       y1="287.44943"
+       x1="-387.84259"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13023"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13017"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13013"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13005"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13003"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientTransform="translate(154.01931,-4.1463699e-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12993"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12989"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12985"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12977"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11674"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11670"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11662"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="287.44943"
+       x2="-371.23654"
+       y1="287.44943"
+       x1="-387.84259"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11654"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11648"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11644"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11636"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11634"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientTransform="translate(154.01931,-4.1463699e-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11624"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11620"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11616"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11608"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientTransform="translate(154.01931,-0.90029535)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8926"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8922"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8918"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8910"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="287.44943"
+       x2="-371.23654"
+       y1="287.44943"
+       x1="-387.84259"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8440"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8433"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8429"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8421"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(0,-0.89973913)"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8419"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       gradientTransform="translate(246.01931,-4.1463699e-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7981"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5867-88"
+       id="linearGradient7932"
+       gradientUnits="userSpaceOnUse"
+       x1="-327.40073"
+       y1="138.68115"
+       x2="-281.86459"
+       y2="138.68115"
+       gradientTransform="translate(154.01931,-4.1463699e-4)" />
+    <linearGradient
+       id="linearGradient7924">
+      <stop
+         id="stop7926"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop7928"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       id="linearGradient7922"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-88">
+      <stop
+         id="stop5869-12"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-1"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       id="linearGradient6967-5"
+       xlink:href="#linearGradient5867-88"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7904"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7900"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7892"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       id="linearGradient7432"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7422"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7418"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7410"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.68115"
+       x2="-281.86459"
+       y1="138.68115"
+       x1="-327.40073"
+       id="linearGradient6967"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="287.44943"
+       x2="-371.23654"
+       y1="287.44943"
+       x1="-387.84259"
+       id="linearGradient6959"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6949"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6945"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6937"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6497"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6493"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6485"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5264"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5260"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5252"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-82">
+      <stop
+         id="stop5869-2"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-6"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="translate(-105.07028,-2.0739375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5397-54"
+       xlink:href="#linearGradient5867-82"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-2">
+      <stop
+         id="stop5869-4"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-3"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="translate(-105.07028,-2.0739375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5397-5"
+       xlink:href="#linearGradient5867-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5403"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="920.40436"
+       x2="2397.3689"
+       y1="920.40436"
+       x1="2284.8362"
+       id="linearGradient7367"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4517">
+      <stop
+         id="stop4519"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4521"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4510">
+      <stop
+         id="stop4512"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4514"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4503">
+      <stop
+         id="stop4505"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4507"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-11">
+      <stop
+         id="stop3858-61"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-97"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4492">
+      <stop
+         id="stop4494"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4496"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-7-2">
+      <stop
+         id="stop3858-55-2"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-74-0"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13623"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13619"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13611"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13165"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13161"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13153"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="matrix(0.99999929,0,0,0.98614895,-280.5697,-0.05816442)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12709"
+       xlink:href="#linearGradient5867-5-29"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="translate(-247.36931,-2.5813017)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12707"
+       xlink:href="#linearGradient3856-6-73"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,-147.12225,26.027448)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12705"
+       xlink:href="#linearGradient3856-97-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="412.62933"
+       x2="108.65295"
+       y1="412.62933"
+       x1="-595.83929"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12703"
+       xlink:href="#linearGradient3856-10"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-6-78-32">
+      <stop
+         id="stop3858-71-3-9"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-7"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-6-78-32"
+       id="linearGradient10572-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-105.07028,-2.0739375)"
+       x1="61.56308"
+       y1="140.46777"
+       x2="237.56308"
+       y2="140.46777" />
+    <linearGradient
+       id="linearGradient3856-6-78-8">
+      <stop
+         id="stop3858-71-3-29"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-5"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-6-78-8"
+       id="linearGradient10572-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-105.07028,-2.0739375)"
+       x1="61.56308"
+       y1="140.46777"
+       x2="237.56308"
+       y2="140.46777" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12437"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12433"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient12425"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11858"
+       xlink:href="#linearGradient3856-97"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-97-8">
+      <stop
+         id="stop3858-68-0"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-11-7"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5859-2-9"
+       xlink:href="#linearGradient3856-97-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10781">
+      <stop
+         id="stop10783"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10785"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10779"
+       xlink:href="#linearGradient3856-97"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10773">
+      <stop
+         id="stop10775"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10777"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10555-0"
+       xlink:href="#linearGradient3856-97"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10718">
+      <stop
+         id="stop10720"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10722"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10711">
+      <stop
+         id="stop10713"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10715"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-78-3">
+      <stop
+         id="stop3858-71-3-2"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6-3"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10696">
+      <stop
+         id="stop10698"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10700"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10685">
+      <stop
+         id="stop10687"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10689"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10683"
+       xlink:href="#linearGradient3856-97"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10677">
+      <stop
+         id="stop10679"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10681"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5865-4"
+       xlink:href="#linearGradient3856-97"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10624">
+      <stop
+         id="stop10626"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10628"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10617">
+      <stop
+         id="stop10619"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10621"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10610">
+      <stop
+         id="stop10612"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop10614"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-97">
+      <stop
+         id="stop3858-68"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-11"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-78">
+      <stop
+         id="stop3858-71-3"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-6"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="140.46777"
+       x2="237.56308"
+       y1="140.46777"
+       x1="61.56308"
+       gradientTransform="translate(-248.36932,-2.5813017)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10146-3"
+       xlink:href="#linearGradient3856-6-78"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10555"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-5-9">
+      <stop
+         id="stop5869-1-5"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-8-4"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-74">
+      <stop
+         id="stop3858-71-0"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-67">
+      <stop
+         id="stop3858-6"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-85"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867-5-29">
+      <stop
+         id="stop5869-1-00"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-8-2"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-73">
+      <stop
+         id="stop3858-71-7"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-4"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-45-3-2">
+      <stop
+         id="stop3858-4-8-7"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-81-5-0"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-10">
+      <stop
+         id="stop3858-05"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-1"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-45-3">
+      <stop
+         id="stop3858-4-8"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-81-5"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-45-3"
+       id="linearGradient9754-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,99.531372,25.216232)"
+       x1="-344.67334"
+       y1="145.9536"
+       x2="105.38848"
+       y2="145.9536" />
+    <linearGradient
+       id="linearGradient3856-45">
+      <stop
+         id="stop3858-4"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-81"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4406-0"
+       xlink:href="#linearGradient3856-45"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5867-5-2">
+      <stop
+         id="stop5869-1-0"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-8-3"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9536">
+      <stop
+         id="stop9538"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop9540"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6-7">
+      <stop
+         id="stop3858-71-4"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8-3"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-1">
+      <stop
+         id="stop3858-14"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-20"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9264">
+      <stop
+         id="stop9266"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop9268"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867-5">
+      <stop
+         id="stop5869-1"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-8"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-6">
+      <stop
+         id="stop3858-71"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-8"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867-8-5">
+      <stop
+         id="stop5869-7-6"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-4-3"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.79079"
+       x2="236.92349"
+       y1="138.79079"
+       x1="-348.09015"
+       id="linearGradient5873-3-3"
+       xlink:href="#linearGradient5867-8-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8308">
+      <stop
+         id="stop8310"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop8312"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8306"
+       xlink:href="#linearGradient3856-27"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-27">
+      <stop
+         id="stop3858-2"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-90"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3492-8"
+       xlink:href="#linearGradient3856-27"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8250">
+      <stop
+         id="stop8252"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop8254"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867-8">
+      <stop
+         id="stop5869-7"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-4"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7647">
+      <stop
+         id="stop7649"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop7651"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7645"
+       xlink:href="#linearGradient3856-77"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-77">
+      <stop
+         id="stop3858-7"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-0"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3492-2"
+       xlink:href="#linearGradient3856-77"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7589">
+      <stop
+         id="stop7591"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop7593"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867-4">
+      <stop
+         id="stop5869-5"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871-9"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7530"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7526"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7518"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7104"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7102"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6656"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6317"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-2-8">
+      <stop
+         id="stop3858-1-7"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-73-5"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3856-2-8"
+       id="linearGradient6215-4"
+       gradientUnits="userSpaceOnUse"
+       x1="-580.12299"
+       y1="1049.3584"
+       x2="-534.38489"
+       y2="1049.3584"
+       gradientTransform="translate(10.445229,-1.0229601)" />
+    <linearGradient
+       id="linearGradient3856-2">
+      <stop
+         id="stop3858-1"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-73"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1049.3584"
+       x2="-534.38489"
+       y1="1049.3584"
+       x1="-580.12299"
+       id="linearGradient6198-7"
+       xlink:href="#linearGradient3856-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6188"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6186"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5712"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5710"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5708"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5706"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5704"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5702"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5700"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5698"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5696"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5694"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="260.3374"
+       x2="105.69164"
+       y1="260.3374"
+       x1="83.691643"
+       id="linearGradient5576"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective9" />
+    <linearGradient
+       id="linearGradient5424">
+      <stop
+         id="stop5426"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop5428"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-7">
+      <stop
+         id="stop3858-55"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-74"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5344">
+      <stop
+         id="stop5346"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop5348"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5216-2-9">
+      <stop
+         id="stop5218-6-4"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop5220-6-3"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5268">
+      <stop
+         id="stop5270"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop5272"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5216-2">
+      <stop
+         id="stop5218-6"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop5220-6"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-94">
+      <stop
+         id="stop3858-3"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-2"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9166"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1038.1689"
+       x2="2324.1321"
+       y1="1038.1689"
+       x1="2295.6143"
+       id="linearGradient9155"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3472">
+      <stop
+         id="stop3474"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop3476"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5216">
+      <stop
+         id="stop5218"
+         offset="0"
+         style="stop-color:#dbdee0;stop-opacity:1;" />
+      <stop
+         id="stop5220"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4926"
+       id="linearGradient3455"
+       gradientUnits="userSpaceOnUse"
+       x1="1309.951"
+       y1="1089.2706"
+       x2="1402.2245"
+       y2="1089.2706"
+       gradientTransform="translate(-79.138944,-38.444717)" />
+    <linearGradient
+       id="linearGradient3426">
+      <stop
+         style="stop-color:#232629;stop-opacity:1;"
+         offset="0"
+         id="stop3428" />
+      <stop
+         style="stop-color:#232629;stop-opacity:1;"
+         offset="1"
+         id="stop3430" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1089.2706"
+       x2="1402.2245"
+       y1="1089.2706"
+       x1="1309.951"
+       id="linearGradient3424"
+       xlink:href="#linearGradient4926"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4926">
+      <stop
+         style="stop-color:#232629;stop-opacity:1;"
+         offset="0"
+         id="stop4928" />
+      <stop
+         style="stop-color:#232629;stop-opacity:1;"
+         offset="1"
+         id="stop4930" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1089.2706"
+       x2="1402.2245"
+       y1="1089.2706"
+       x1="1309.951"
+       id="linearGradient4995"
+       xlink:href="#linearGradient4926"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8877"
+       xlink:href="#linearGradient3856-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8875"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8873"
+       xlink:href="#linearGradient3856-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8871"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8869"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8867"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientTransform="translate(-153.98289,90.060334)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8865"
+       xlink:href="#linearGradient3856-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8863"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="355.87778"
+       x2="421.4332"
+       y1="355.87778"
+       x1="416.93951"
+       gradientTransform="translate(-0.30005314,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8861"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8859"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.58937"
+       x2="543.96741"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8857"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8447"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8443"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8435"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8019"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8015"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8007"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3856-9">
+      <stop
+         id="stop3858-0"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-9"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5863-5"
+       xlink:href="#linearGradient3856-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7543"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7341"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7137"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6883"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6879"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6871"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6459"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6447"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="412.62933"
+       x2="108.65295"
+       y1="412.62933"
+       x1="-595.83929"
+       id="linearGradient6023"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="138.98634"
+       x2="99.085938"
+       y1="138.98634"
+       x1="-595.75684"
+       id="linearGradient5931"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5865"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5863"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5861"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5859"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5857"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="557.13818"
+       x2="488.11179"
+       y1="557.13818"
+       x1="474.11179"
+       id="linearGradient5568"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="185.97433"
+       x2="-423.70938"
+       y1="185.97433"
+       x1="-455.69571"
+       id="linearGradient4939"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="184.61887"
+       x2="-400.31876"
+       y1="184.61887"
+       x1="-467.19376"
+       id="linearGradient4767"
+       xlink:href="#linearGradient4560"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4560">
+      <stop
+         id="stop4562"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop4564"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856-4">
+      <stop
+         id="stop3858-5"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860-7"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4515"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4472"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="397.65405"
+       x2="453.00928"
+       y1="397.65405"
+       x1="431.20428"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4470"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="524.59497"
+       x2="639.1156"
+       y1="524.59497"
+       x1="634.62195"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4468"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4466"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4464"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3492"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3609"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="221.33762"
+       x2="-417.13516"
+       y1="221.33762"
+       x1="-467.34512"
+       id="linearGradient4486"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4408"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4366"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4364"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4362"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4288"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4273"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.98903103,0,0,1.0001402,5.7807857,-0.05969699)"
+       gradientUnits="userSpaceOnUse"
+       y2="445.24039"
+       x2="570.48511"
+       y1="406.03897"
+       x1="570.48511"
+       id="linearGradient4259"
+       xlink:href="#linearGradient4245"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.290128,0,0,0.77830794,98.768524,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4237"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4235"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(0.98585011,0,0,0.77830794,-6.623518,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4195"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4193"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(0.98395085,0,0,0.77830794,-7.2813589,26.511288)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4108"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4106"
+       xlink:href="#linearGradient4197"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="395.46878"
+       x2="209.60085"
+       y1="395.46878"
+       x1="197.93234"
+       id="linearGradient4058"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1.0003619,0,0,0.14156624,0.01136409,97.590745)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4040"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="145.9536"
+       x2="105.38848"
+       y1="145.9536"
+       x1="-344.67334"
+       gradientTransform="matrix(1,0,0,0.78698562,0,23.25948)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4024"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="169.5769"
+       x2="138.83263"
+       y1="169.58937"
+       x1="-330.97958"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4022"
+       xlink:href="#linearGradient3990"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="514.716"
+       x2="123.01467"
+       y1="110.92937"
+       x1="-308.13144"
+       gradientTransform="matrix(0.965897,0,0,1.2444143,-28.482631,-49.561268)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3974"
+       xlink:href="#linearGradient3856"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="736.81"
+       x2="880.45819"
+       y1="408.8381"
+       x1="416.70969"
+       id="linearGradient3934"
+       xlink:href="#linearGradient3928"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3766">
+      <stop
+         id="stop3768"
+         offset="0"
+         style="stop-color:#789fc5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b3c7db;stop-opacity:0.990991;"
+         offset="0.5"
+         id="stop3854" />
+      <stop
+         id="stop3770"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3856">
+      <stop
+         id="stop3858"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3860"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="0"
+         id="stop3866" />
+      <stop
+         id="stop3874"
+         offset="0.51315862"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3870"
+         offset="0.64315861"
+         style="stop-color:#8bcff2;stop-opacity:1;" />
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="0.76999998"
+         id="stop3872" />
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="1"
+         id="stop3868" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3900">
+      <stop
+         style="stop-color:#2a78a0;stop-opacity:1;"
+         offset="0"
+         id="stop3902" />
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="1"
+         id="stop3904" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3906">
+      <stop
+         style="stop-color:#9e9e9e;stop-opacity:1;"
+         offset="0"
+         id="stop3908" />
+      <stop
+         id="stop3910"
+         offset="0.11111111"
+         style="stop-color:#c7c7c7;stop-opacity:0.990991;" />
+      <stop
+         style="stop-color:#eff0f1;stop-opacity:1;"
+         offset="1"
+         id="stop3912" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3928">
+      <stop
+         id="stop3930"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.97297299;" />
+      <stop
+         style="stop-color:#7f7f7f;stop-opacity:0.13513513;"
+         offset="0.5"
+         id="stop3936" />
+      <stop
+         id="stop3932"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3950">
+      <stop
+         style="stop-color:#2a78a0;stop-opacity:1;"
+         offset="0"
+         id="stop3952" />
+      <stop
+         style="stop-color:#eff0f1;stop-opacity:1;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3958">
+      <stop
+         id="stop3960"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop3964"
+         offset="1"
+         style="stop-color:#eff0f1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3990">
+      <stop
+         id="stop3992"
+         offset="0"
+         style="stop-color:#287196;stop-opacity:1;" />
+      <stop
+         style="stop-color:#3394c5;stop-opacity:1;"
+         offset="0.13"
+         id="stop3998" />
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="0.41944444"
+         id="stop3996" />
+      <stop
+         id="stop3994"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4128">
+      <stop
+         style="stop-color:#287196;stop-opacity:1;"
+         offset="0"
+         id="stop4130" />
+      <stop
+         id="stop4132"
+         offset="0.13"
+         style="stop-color:#3394c5;stop-opacity:1;" />
+      <stop
+         id="stop4134"
+         offset="0.41999999"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         style="stop-color:#3daee9;stop-opacity:1;"
+         offset="0.57999998"
+         id="stop4138" />
+      <stop
+         id="stop4140"
+         offset="0.78999996"
+         style="stop-color:#3394c5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#287196;stop-opacity:1;"
+         offset="1"
+         id="stop4136" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4197">
+      <stop
+         style="stop-color:#287196;stop-opacity:1;"
+         offset="0"
+         id="stop4199" />
+      <stop
+         style="stop-color:#287196;stop-opacity:1;"
+         offset="1"
+         id="stop4201" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4245">
+      <stop
+         id="stop4247"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.64313728;"
+         offset="0.5"
+         id="stop4261" />
+      <stop
+         id="stop4249"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.2882883;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4692">
+      <stop
+         id="stop4694"
+         offset="0"
+         style="stop-color:#c2c2c2;stop-opacity:1;" />
+      <stop
+         id="stop4696"
+         offset="1"
+         style="stop-color:#9e9e9e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5867">
+      <stop
+         id="stop5869"
+         offset="0"
+         style="stop-color:#babec2;stop-opacity:1;" />
+      <stop
+         id="stop5871"
+         offset="1"
+         style="stop-color:#babec2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9123">
+      <stop
+         id="stop9125"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#9ed6f4;stop-opacity:1;"
+         offset="0.70652175"
+         id="stop9131" />
+      <stop
+         id="stop9127"
+         offset="1"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6426">
+      <stop
+         style="stop-color:#eff0f1;stop-opacity:1;"
+         offset="0"
+         id="stop6428" />
+      <stop
+         style="stop-color:#e7e8e9;stop-opacity:1;"
+         offset="1"
+         id="stop6430" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6450">
+      <stop
+         id="stop6452"
+         offset="0"
+         style="stop-color:#3daee9;stop-opacity:1;" />
+      <stop
+         id="stop6454"
+         offset="1"
+         style="stop-color:#1998da;stop-opacity:1;" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146-1" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-3" />
+    <inkscape:perspective
+       id="perspective4090-8-3"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146-2" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-2" />
+    <inkscape:perspective
+       id="perspective4090-8-5"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146-9" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-5" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-89" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-9" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-0" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4090-29" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.576748"
+     inkscape:cx="10.883861"
+     inkscape:cy="8.2775479"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="1195"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <path
+       transform="matrix(0.61871345,-0.02669387,0.02759764,0.63966091,3.7267521,1034.6764)"
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       inkscape:transform-center-x="-0.020262416"
+       inkscape:transform-center-y="-0.80422869"
+       d="M 24.313486,8.3401038 17.582059,14.312506 18.777698,23.742371 10.920235,18.724484 2.6451568,23.06914 4.676026,13.773921 -1.4985805,7.2629332 6.5676902,7.599549 11.825069,-1.5610508 16.247215,8.003488 z"
+       id="path13184"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_symbolshapes.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_symbolshapes.svg
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_symbolshapes_smiley.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146" />
+    <inkscape:perspective
+       id="perspective4146-3"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146-3-8" />
+    <inkscape:perspective
+       id="perspective4146-0"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146-3-7" />
+    <inkscape:perspective
+       id="perspective4146-36"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="6.9999886"
+       x2="26.21154"
+       y1="43.999989"
+       x1="26.21154"
+       id="linearGradient4416-2"
+       xlink:href="#linearGradient4435-3"
+       inkscape:collect="always"
+       gradientTransform="matrix(-1.4054053,0,0,1.4054053,804.69502,154.09579)" />
+    <linearGradient
+       gradientTransform="translate(0,-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="177.93361"
+       x2="768.85718"
+       y1="201.93361"
+       x1="768.85718"
+       id="linearGradient4179-4"
+       xlink:href="#linearGradient4344-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4400-7">
+      <stop
+         style="stop-color:#020303;stop-opacity:1"
+         offset="0"
+         id="stop4402-9" />
+      <stop
+         style="stop-color:#424649;stop-opacity:0"
+         offset="1"
+         id="stop4404-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="44"
+       x2="43.999996"
+       y1="19.999998"
+       x1="19.999998"
+       id="linearGradient4394-8"
+       xlink:href="#linearGradient4400-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4435-3">
+      <stop
+         style="stop-color:#c61423;stop-opacity:1"
+         offset="0"
+         id="stop4437-3" />
+      <stop
+         style="stop-color:#dc2b41;stop-opacity:1"
+         offset="1"
+         id="stop4439-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4344-0"
+       inkscape:collect="always">
+      <stop
+         id="stop4346-8"
+         offset="0"
+         style="stop-color:#ed868d;stop-opacity:1" />
+      <stop
+         id="stop4348-9"
+         offset="1"
+         style="stop-color:#fbe6e8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="6.9999886"
+       x2="26.21154"
+       y1="43.999989"
+       x1="26.21154"
+       id="linearGradient4416"
+       xlink:href="#linearGradient4435"
+       inkscape:collect="always"
+       gradientTransform="matrix(-1.4054053,0,0,1.4054053,804.69502,154.09579)" />
+    <linearGradient
+       gradientTransform="translate(0,-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="177.93361"
+       x2="768.85718"
+       y1="201.93361"
+       x1="768.85718"
+       id="linearGradient4179"
+       xlink:href="#linearGradient4344"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4400">
+      <stop
+         style="stop-color:#020303;stop-opacity:1"
+         offset="0"
+         id="stop4402" />
+      <stop
+         style="stop-color:#424649;stop-opacity:0"
+         offset="1"
+         id="stop4404" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="44"
+       x2="43.999996"
+       y1="19.999998"
+       x1="19.999998"
+       id="linearGradient4394"
+       xlink:href="#linearGradient4400"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4435">
+      <stop
+         style="stop-color:#c61423;stop-opacity:1"
+         offset="0"
+         id="stop4437" />
+      <stop
+         style="stop-color:#dc2b41;stop-opacity:1"
+         offset="1"
+         id="stop4439" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4344"
+       inkscape:collect="always">
+      <stop
+         id="stop4346"
+         offset="0"
+         style="stop-color:#ed868d;stop-opacity:1" />
+      <stop
+         id="stop4348"
+         offset="1"
+         style="stop-color:#fbe6e8;stop-opacity:1" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146-9" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       id="perspective4146-33" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.576748"
+     inkscape:cx="12.184471"
+     inkscape:cy="11.444045"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     units="px"
+     inkscape:window-width="1195"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4120"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4126" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4128" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4132" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4134" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4138" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4140" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4199" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6.0000172"
+       id="guide4201" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <path
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 12 4 C 7.581722 4 4 7.581722 4 12 C 4 16.418278 7.581722 20 12 20 C 16.418278 20 20 16.418278 20 12 C 20 7.581722 16.418278 4 12 4 z M 9 8 C 9.554 8 10 8.446 10 9 C 10 9.554 9.554 10 9 10 C 8.446 10 8 9.554 8 9 C 8 8.446 8.446 8 9 8 z M 15 8 C 15.554 8 16 8.446 16 9 C 16 9.554 15.554 10 15 10 C 14.446 10 14 9.554 14 9 C 14 8.446 14.446 8 15 8 z M 8.15625 14 L 15.84375 14 C 15.400461 15.72689 13.868958 17 12 17 C 10.131042 17 8.599539 15.72689 8.15625 14 z "
+       transform="translate(-1,1029.3622)"
+       id="path4238" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_toggleanchortype.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_toggleanchortype.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_toggleanchortype.svg">
+  <defs
+     id="defs3762" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="10.102417"
+     inkscape:cy="15.757455"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1869"
+     inkscape:window-height="1060"
+     inkscape:window-x="49"
+     inkscape:window-y="-3"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="21.000014,2.9999782"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="6,0"
+       id="guide4155" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4167" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <path
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 12 4 C 10.895431 4 10 4.8954305 10 6 C 10 6.9319805 10.637301 7.7155373 11.5 7.9375 L 11.5 10 L 9 10 L 9 11 L 11.5 11 L 11.5 18.96875 C 8.9609605 18.805981 6.7516066 17.456592 5.40625 15.46875 L 5.59375 15.375 L 6.5 14.875 L 6 14 C 6.0000189 14.000017 3 15.625 3 15.625 L 3.5 16.5 L 4.53125 15.9375 C 6.1354118 18.373143 8.8668472 20 12 20 C 15.133153 20 17.863905 18.373143 19.46875 15.9375 L 20.5 16.5 L 21 15.625 C 21.000014 15.624367 18 14 18 14 L 17.5 14.875 L 18.40625 15.375 L 18.59375 15.46875 C 17.248393 17.456592 15.039039 18.805981 12.5 18.96875 L 12.5 11 L 15 11 L 15 10 L 12.5 10 L 12.5 7.9375 C 13.362699 7.7155373 14 6.9319805 14 6 C 14 4.8954305 13.104569 4 12 4 z M 12 5 C 12.552285 5 13 5.4477153 13 6 C 13 6.5522847 12.552285 7 12 7 C 11.447715 7 11 6.5522847 11 6 C 11 5.4477153 11.447715 5 12 5 z "
+       transform="translate(550.28571,606.64789)"
+       id="rect3870" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_toggleobjectbeziermode.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_toggleobjectbeziermode.svg
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   viewBox="0 0 24 24"
+   sodipodi:docname="lc_bezierfill.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       id="perspective4146"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4146-9"
+       inkscape:persp3d-origin="12 : 8 : 1"
+       inkscape:vp_z="24 : 12 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 12 : 1"
+       sodipodi:type="inkscape:persp3d" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.923172"
+     inkscape:cy="17.407856"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1167"
+     inkscape:window-height="1057"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     units="px"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="3,21"
+       orientation="18,0"
+       id="guide4085" />
+    <sodipodi:guide
+       position="3,3"
+       orientation="0,18"
+       id="guide4087" />
+    <sodipodi:guide
+       position="21,3"
+       orientation="-18,0"
+       id="guide4089" />
+    <sodipodi:guide
+       position="21,21"
+       orientation="0,-18"
+       id="guide4091" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4093" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,16"
+       id="guide4095" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4097" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-16"
+       id="guide4099" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101"
+       originx="1px"
+       originy="0.99998262px" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="16,0"
+       id="guide4123" />
+    <sodipodi:guide
+       position="4,4"
+       orientation="0,2.000001"
+       id="guide4125" />
+    <sodipodi:guide
+       position="5,20"
+       orientation="-16,0"
+       id="guide4127" />
+    <sodipodi:guide
+       position="6.000001,20"
+       orientation="0,-2.000001"
+       id="guide4129" />
+    <sodipodi:guide
+       position="19,20"
+       orientation="16,0"
+       id="guide4131" />
+    <sodipodi:guide
+       position="18,4"
+       orientation="0,2"
+       id="guide4133" />
+    <sodipodi:guide
+       position="20,4"
+       orientation="-16,0"
+       id="guide4135" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-2"
+       id="guide4137" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1,-1029.3622)">
+    <path
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 6,1033.3622 c -1.6568542,0 -3,1.3432 -3,3 0,1.6569 1.3431458,3 3,3 1.6568542,0 3,-1.3431 3,-3 0,-1.6568 -1.3431458,-3 -3,-3 z m 0,2 c 0.5522847,0 1,0.4477 1,1 0,0.5523 -0.4477153,1 -1,1 -0.5522847,0 -1,-0.4477 -1,-1 0,-0.5523 0.4477153,-1 1,-1 z"
+       id="path4019"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 7,1043.3622 c -1.6568542,0 -3,1.3431 -3,3 0,1.6569 1.3431458,3 3,3 1.6568542,0 3,-1.3431 3,-3 0,-1.6569 -1.3431458,-3 -3,-3 z m 0,2 c 0.5522847,0 1,0.4477 1,1 0,0.5523 -0.4477153,1 -1,1 -0.5522847,0 -1,-0.4477 -1,-1 0,-0.5523 0.4477153,-1 1,-1 z"
+       id="path4019-1" />
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 16,1042.3622 c -1.656854,0 -3,1.3431 -3,3 0,1.6569 1.343146,3 3,3 1.656854,0 3,-1.3431 3,-3 0,-1.6569 -1.343146,-3 -3,-3 z m 0,2 c 0.552285,0 1,0.4477 1,1 0,0.5523 -0.447715,1 -1,1 -0.552285,0 -1,-0.4477 -1,-1 0,-0.5523 0.447715,-1 1,-1 z"
+       id="path4019-12" />
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 14,1034.3622 c -1.656854,0 -3,1.3431 -3,3 0,1.6569 1.343146,3 3,3 1.656854,0 3,-1.3431 3,-3 0,-1.6569 -1.343146,-3 -3,-3 z m 0,2 c 0.552285,0 1,0.4477 1,1 0,0.5523 -0.447715,1 -1,1 -0.552285,0 -1,-0.4477 -1,-1 0,-0.5523 0.447715,-1 1,-1 z"
+       id="path4019-3" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4.875,1035.206 0.125,1.25 1,10 0.09375,1 1.03125,-0.094 9,-1 1.125,-0.125 -0.28125,-1.125 -2,-8 -0.15625,-0.6562 -0.6875,-0.094 -8,-1 -1.25,-0.1562 z m 2.25,2.3125 6.0625,0.75 1.5625,6.2187 -6.84375,0.75 -0.78125,-7.7187 z"
+       id="path4123"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="arc"
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path4129"
+       sodipodi:cx="7"
+       sodipodi:cy="7.0000172"
+       sodipodi:rx="1"
+       sodipodi:ry="1"
+       d="m 8,7.0000172 a 1,1 0 1 1 -2,0 1,1 0 1 1 2,0 z"
+       transform="translate(-1,1029.3622)" />
+    <path
+       transform="translate(7,1030.3622)"
+       sodipodi:type="arc"
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path4129-8"
+       sodipodi:cx="7"
+       sodipodi:cy="7.0000172"
+       sodipodi:rx="1"
+       sodipodi:ry="1"
+       d="m 8,7.0000172 a 1,1 0 1 1 -2,0 1,1 0 1 1 2,0 z" />
+    <path
+       transform="translate(9,1038.3622)"
+       sodipodi:type="arc"
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path4129-87"
+       sodipodi:cx="7"
+       sodipodi:cy="7.0000172"
+       sodipodi:rx="1"
+       sodipodi:ry="1"
+       d="m 8,7.0000172 a 1,1 0 1 1 -2,0 1,1 0 1 1 2,0 z" />
+    <path
+       transform="translate(0,1039.3622)"
+       sodipodi:type="arc"
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path4129-9"
+       sodipodi:cx="7"
+       sodipodi:cy="7.0000172"
+       sodipodi:rx="1"
+       sodipodi:ry="1"
+       d="m 8,7.0000172 a 1,1 0 1 1 -2,0 1,1 0 1 1 2,0 z" />
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_toggleobjectrotatemode.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_toggleobjectrotatemode.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   id="svg3760"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="lc_lineendstyle.svg">
+  <defs
+     id="defs3762" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="24.451298"
+     inkscape:cx="7.918308"
+     inkscape:cy="7.9556416"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1167"
+     inkscape:window-height="1053"
+     inkscape:window-x="56"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="false"
+     showguides="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4106"
+       originx="1.8863594e-05px"
+       originy="-1.7016406e-05px" />
+    <sodipodi:guide
+       position="3.0000144,20.999978"
+       orientation="0,18"
+       id="guide4229" />
+    <sodipodi:guide
+       position="21.000014,20.999978"
+       orientation="18,0"
+       id="guide4231" />
+    <sodipodi:guide
+       position="21.000014,2.9999782"
+       orientation="0,-18"
+       id="guide4233" />
+    <sodipodi:guide
+       position="3.0000144,2.9999782"
+       orientation="-18,0"
+       id="guide4235" />
+    <sodipodi:guide
+       position="20.000014,3.9999782"
+       orientation="0,-16"
+       id="guide4241" />
+    <sodipodi:guide
+       position="4,20"
+       orientation="6,0"
+       id="guide4155" />
+    <sodipodi:guide
+       position="20,14"
+       orientation="-6,0"
+       id="guide4167" />
+    <sodipodi:guide
+       position="20,20"
+       orientation="0,-6"
+       id="guide4169" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3765">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-550.28571,-606.64789)">
+    <g
+       transform="translate(-2.43682,24.528647)"
+       id="layer1-9"
+       inkscape:label="Capa 1">
+      <path
+         id="rect4148"
+         transform="translate(553.72253,583.11926)"
+         d="m 3,3 0,16 1,0 6,0 0,-1 -6,0 0,-14 8,0 0,2 0,1 0,4 1,0 0,-3.8613281 C 14.726297,7.5823641 16,9.13145 16,11 l 0,1 -5,0 0,1 0,6 1,0 7,0 0,-1 0,-5 0,-1 -2,0 0,-1 C 17,8.5728315 15.287361,6.5606036 13,6.0996094 L 13,3 4,3 3,3 z m 9,10 6,0 0,5 -6,0 0,-5 z"
+         style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Breeze/actions/LO_lc_icons_breeze/lc_zoom.svg
+++ b/Breeze/actions/LO_lc_icons_breeze/lc_zoom.svg
@@ -1,0 +1,1 @@
+lc_zoomoptimal.svg


### PR DESCRIPTION
writer search toolbar
the next search result is lc_downsearch but the last search result is up_small and this icon is in the folder svtools AND has the size 16x16px. there is also up_large (26x26px) but this icon doesn't work.
I need 30 min to found the "right" icon. I don't think it was a good idea to use up_small but yeah. we can make the links.txt file where the linked files were listed like for the sifr icon theme 
svtools/res/up_small.png cmd/sc_upsearch.png
![writer search toolbar](https://dl.dropboxusercontent.com/u/1642456/vdg/plasma-next-icons-working/action/toolbar/LO/writerSearch.png)
![writer search toolbar](https://dl.dropboxusercontent.com/u/1642456/vdg/plasma-next-icons-working/action/toolbar/LO/writerSearch-b.png)
