### PR TITLE
put sizes in the theme description

### DIFF
--- a/Breeze Dark/index.theme
+++ b/Breeze Dark/index.theme
@@ -77,6 +77,19 @@ Inherits=Breeze
 
 Example=folder
 
+DesktopDefault=48
+DesktopSizes=16,22,32,48,64,128,256
+ToolbarDefault=22
+ToolbarSizes=16,22,32,48
+MainToolbarDefault=22
+MainToolbarSizes=16,22,32,48
+SmallDefault=16
+SmallSizes=16,22,32,48
+PanelDefault=32
+PanelSizes=16,22,32,48,64,128,256
+DialogDefault=32
+DialogSizes=16,22,32,48,64,128,256
+
 ########## Directories
 ########## ordered by category and alphabetically
 

--- a/Breeze/index.theme
+++ b/Breeze/index.theme
@@ -77,6 +77,19 @@ Inherits=hicolor
 
 Example=folder
 
+DesktopDefault=48
+DesktopSizes=16,22,32,48,64,128,256
+ToolbarDefault=22
+ToolbarSizes=16,22,32,48
+MainToolbarDefault=22
+MainToolbarSizes=16,22,32,48
+SmallDefault=16
+SmallSizes=16,22,32,48
+PanelDefault=32
+PanelSizes=16,22,32,48,64,128,256
+DialogDefault=32
+DialogSizes=16,22,32,48,64,128,256
+
 ########## Directories
 ########## ordered by category and alphabetically
 


### PR DESCRIPTION
This fixes the bug
https://bugs.kde.org/show_bug.cgi?id=346254
the icons kcm needs them in order to make the size chooser dialog work
doesn't have effects on the look and feel of the theme