### PR TITLE
Fix LibreOffice_Breeze/breeze/formula/res/fapok.svg link to it's relative path

### DIFF
--- a/LibreOffice_Breeze/breeze/formula/res/fapok.svg
+++ b/LibreOffice_Breeze/breeze/formula/res/fapok.svg
@@ -1,1 +1,1 @@
-/home/andreas/Schreibtisch/plasma-next-icons/LibreOffice_Breeze/breeze/cmd/sc_ok.svg
+../../cmd/sc_ok.svg


### PR DESCRIPTION
LibreOffice_Breeze/breeze/formula/res/fapok.svg was wrongly linked using an absolute path.