### PR TITLE
security-high in gray instead of green

### DIFF
--- a/Breeze Dark/status/toolbar/security-high.svg
+++ b/Breeze Dark/status/toolbar/security-high.svg
@@ -25,7 +25,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="12.351886"
+     inkscape:cx="5.695636"
      inkscape:cy="13.499783"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -80,9 +80,17 @@
      id="layer1"
      transform="translate(0,-1030.3622)">
     <path
-       style="fill:#27ae60;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 11 3 L 5 4 L 5 12 C 5.016813 15.5683 6.9950654 17.792 11 19 C 15.004935 17.792 16.98319 15.5683 17 12 L 17 4 L 11 3 z M 14.576172 5.734375 L 15.423828 6.2636719 L 10.150391 14.701172 L 6.7226562 12.414062 L 7.2773438 11.582031 L 9.8496094 13.296875 L 14.576172 5.734375 z "
+       style="fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 11,3 -7,1 0,8 c 0.016813,3.5683 2.9950654,5.792 7,7 4.004935,-1.208 6.98319,-3.4317 7,-7 l 0,-8 z m 3.576172,2.734375 0.847656,0.5292969 -5.273437,8.4375001 -3.4277348,-2.28711 0.5546876,-0.832031 2.5722656,1.714844 z"
        transform="translate(0,1030.3622)"
-       id="path4145-9" />
+       id="path4145-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccc" />
+    <path
+       style="fill:#2ecc71;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 14.576172,1036.0966 0.847656,0.5293 -5.273437,8.4375 -3.4277348,-2.2871 0.5546876,-0.8321 2.5722656,1.7149 z"
+       id="path4145-9-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
   </g>
 </svg>

--- a/Breeze Dark/status/toolbar/security-low.svg
+++ b/Breeze Dark/status/toolbar/security-low.svg
@@ -25,7 +25,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="11.105725"
+     inkscape:cx="6.386975"
      inkscape:cy="11.399264"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -81,8 +81,10 @@
      transform="translate(0,-1030.3622)">
     <path
        style="fill:#da4453;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 11 3 L 5 4 L 5 12 C 5.016813 15.5683 6.9950654 17.792 11 19 C 15.004935 17.792 16.98319 15.5683 17 12 L 17 4 L 11 3 z M 7.3730469 5.1679688 L 11 9.2480469 L 14.626953 5.1679688 L 15.373047 5.8320312 L 11.667969 10 L 15.373047 14.167969 L 14.626953 14.832031 L 11 10.751953 L 7.3730469 14.832031 L 6.6269531 14.167969 L 10.332031 10 L 6.6269531 5.8320312 L 7.3730469 5.1679688 z "
+       d="m 11,3 -7,1 0,8 c 0.016813,3.5683 2.9950654,5.792 7,7 4.004935,-1.208 6.98319,-3.4317 7,-7 L 18,4 Z M 7.3730469,5.1679688 11,9.2480469 14.626953,5.1679688 15.373047,5.8320312 11.667969,10 15.373047,14.167969 14.626953,14.832031 11,10.751953 7.3730469,14.832031 6.6269531,14.167969 10.332031,10 6.6269531,5.8320312 Z"
        transform="translate(0,1030.3622)"
-       id="path4145" />
+       id="path4145"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
   </g>
 </svg>

--- a/Breeze Dark/status/toolbar/security-medium.svg
+++ b/Breeze Dark/status/toolbar/security-medium.svg
@@ -24,9 +24,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="45.254834"
-     inkscape:cx="14.950878"
-     inkscape:cy="8.859036"
+     inkscape:zoom="22.627417"
+     inkscape:cx="6.7596363"
+     inkscape:cy="9.4355752"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -81,22 +81,8 @@
      transform="translate(0,-1030.3622)">
     <path
        style="fill:#fdbc4b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 11 3 L 5 4 L 5 12 C 5.016813 15.5683 6.9950654 17.792 11 19 C 15.004935 17.792 16.98319 15.5683 17 12 L 17 4 L 11 3 z "
+       d="M 11 3 L 4 4 L 4 12 C 4.016813 15.5683 6.9950654 17.792 11 19 C 15.004935 17.792 17.98319 15.5683 18 12 L 18 4 L 11 3 z M 10.5 5 L 11.5 5 L 11.5 13 L 10.5 13 L 10.5 5 z M 10.5 14 L 11.5 14 L 11.5 15 L 10.5 15 L 10.5 14 z "
        transform="translate(0,1030.3622)"
        id="path4145" />
-    <rect
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4145"
-       width="1"
-       height="8.0000172"
-       x="10.5"
-       y="1035.3622" />
-    <rect
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4147"
-       width="1"
-       height="0.99996519"
-       x="10.5"
-       y="1044.3622" />
   </g>
 </svg>

--- a/Breeze/status/toolbar/security-high.svg
+++ b/Breeze/status/toolbar/security-high.svg
@@ -25,7 +25,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="7.633136"
+     inkscape:cx="5.695636"
      inkscape:cy="13.499783"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -80,11 +80,17 @@
      id="layer1"
      transform="translate(0,-1030.3622)">
     <path
-       style="fill:#27ae60;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 11,3 -7,1 0,8 c 0.016813,3.5683 2.9950654,5.792 7,7 4.004935,-1.208 6.98319,-3.4317 7,-7 l 0,-8 z m 3.576172,2.734375 0.847656,0.5292969 -5.273437,8.4375001 -3.4277348,-2.28711 0.5546876,-0.832031 2.5722656,1.714844 z"
        transform="translate(0,1030.3622)"
        id="path4145-9"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccccccccccc" />
+    <path
+       style="fill:#2ecc71;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 14.576172,1036.0966 0.847656,0.5293 -5.273437,8.4375 -3.4277348,-2.2871 0.5546876,-0.8321 2.5722656,1.7149 z"
+       id="path4145-9-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
   </g>
 </svg>


### PR DESCRIPTION
because green is standard and all system-tray icons are gray
so green would flash to much I think

Signed-off-by: andreask <kainz.a@gmail.com>